### PR TITLE
chore - fix approve id and change approved wording

### DIFF
--- a/app/views/claim/view-claim.html
+++ b/app/views/claim/view-claim.html
@@ -154,7 +154,7 @@
           <td class="claim-expense-response">
             <select id="claim-expense-{{ expense.ClaimExpenseId }}-status" data-id="{{ expense.ClaimExpenseId }}" name="claim-expense-{{ expense.ClaimExpenseId }}-status" class="form-control action-select claim-expense-status">
               <option {% if expense['Status'] == undefined %} selected {% endif %}>Select</option>
-              <option {% if expense['Status'] == 'APPROVED' %} selected {% endif %} value="APPROVED">Approved</option>
+              <option {% if expense['Status'] == 'APPROVED' %} selected {% endif %} value="APPROVED">Approve</option>
               <option {% if expense['Status'] == 'APPROVED-DIFF-AMOUNT' %} selected {% endif %} value="APPROVED-DIFF-AMOUNT" >Approve different amount</option>
               <option {% if expense['Status'] == 'REQUEST-INFORMATION' %} selected {% endif %} value="REQUEST-INFORMATION">Request information</option>
               <option {% if expense['Status'] == 'REJECTED' %} selected {% endif %} value="REJECTED">Reject claim</option>
@@ -180,7 +180,7 @@
 
     <div id="decision" class="form-group {% if errors['decision'][0] %} error {% endif %}">
       <fieldset id='reason' >
-        <label for="accept" class="block-label inline" data-target="accept-input">
+        <label for="approve" class="block-label inline" data-target="accept-input">
           <input type="radio" name="decision" value="APPROVED" id="approve" {% if claimDecision['decision'] == 'APPROVED' %} checked {% endif %}>
           <span>Approve</span>
         </label>

--- a/test/e2e/spec.js
+++ b/test/e2e/spec.js
@@ -40,8 +40,8 @@ describe('First time claim viewing flow', () => {
         expect(text).to.be.equal('John Smith')
       })
       .selectByVisibleText('#nomis-check', 'Approve')
-      .selectByVisibleText(`#claim-expense-${expenseId1}-status`, 'Approved')
-      .selectByVisibleText(`#claim-expense-${expenseId2}-status`, 'Approved')
+      .selectByVisibleText(`#claim-expense-${expenseId1}-status`, 'Approve')
+      .selectByVisibleText(`#claim-expense-${expenseId2}-status`, 'Approve')
       .click('#approve')
       .click('#approve-submit')
 


### PR DESCRIPTION
- Fixed id of overall claim approve button
- Changed text of each claim expense approval to be `approve` instead of `approved` (to be consistent with the wording/tense of other actions on the page)

## Checklist

- [ ] Unit tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated

