### PR TITLE
Feature/apvs 349/update view claim to display child expenses and child details

### DIFF
--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -18,6 +18,7 @@ module.exports = function (router) {
           title: 'APVS Claim',
           Claim: data.claim,
           Expenses: data.claimExpenses,
+          Children: data.claimChild,
           getDateFormatted: getDateFormatted,
           getClaimExpenseDetailFormatted: getClaimExpenseDetailFormatted,
           getDisplayFieldName: getDisplayFieldName,
@@ -30,8 +31,17 @@ module.exports = function (router) {
   router.post('/claim/:claimId', function (req, res) {
     try {
       var claimExpenses = getClaimExpenseResponses(req.body)
-      var claimDecision = new ClaimDecision(req.body.decision, req.body.reasonRequest, req.body.reasonReject,
-        req.body.additionalInfoApprove, req.body.additionalInfoRequest, req.body.additionalInfoReject, req.body.nomisCheck, req.body.dwpCheck, claimExpenses)
+      var claimDecision = new ClaimDecision(
+        req.body.decision,
+        req.body.reasonRequest,
+        req.body.reasonReject,
+        req.body.additionalInfoApprove,
+        req.body.additionalInfoRequest,
+        req.body.additionalInfoReject,
+        req.body.nomisCheck,
+        req.body.dwpCheck,
+        claimExpenses
+      )
 
       SubmitClaimResponse(req.params.claimId, claimDecision)
         .then(function () {

--- a/app/services/data/get-individual-claim-details.js
+++ b/app/services/data/get-individual-claim-details.js
@@ -35,17 +35,7 @@ module.exports = function (claimId) {
       return knex('Claim')
         .join('ClaimExpense', 'Claim.ClaimId', '=', 'ClaimExpense.ClaimId')
         .where('Claim.ClaimId', claimId)
-        .select('ClaimExpense.ExpenseType',
-          'ClaimExpense.Cost',
-          'ClaimExpense.ApprovedCost',
-          'ClaimExpense.Status',
-          'ClaimExpense.To',
-          'ClaimExpense.From',
-          'ClaimExpense.IsReturn',
-          'ClaimExpense.TravelTime',
-          'ClaimExpense.DurationOfTravel',
-          'ClaimExpense.TicketType',
-          'ClaimExpense.ClaimExpenseId')
+        .select()
         .orderBy('ClaimExpense.ClaimExpenseId')
         .then(function (claimExpenses) {
           var total = 0
@@ -63,12 +53,7 @@ module.exports = function (claimId) {
           return knex('Claim')
             .join('ClaimChild', 'Claim.ClaimId', '=', 'ClaimChild.ClaimId')
             .where({ 'Claim.ClaimId': claimId, 'ClaimChild.IsEnabled': true })
-            .select(
-              'ClaimChild.ClaimChildId',
-              'ClaimChild.Name',
-              'ClaimChild.DateOfBirth',
-              'ClaimChild.Relationship'
-            )
+            .select()
             .orderBy('ClaimChild.Name')
             .then(function (claimChild) {
               return {

--- a/app/views/claim/view-claim.html
+++ b/app/views/claim/view-claim.html
@@ -39,6 +39,13 @@
   	    <td id="visitor-name">{{ Claim['FirstName'] }} {{ Claim['LastName'] }}</td>
   	  </tr>
 
+      {% for child in Children %}
+      <tr>
+        <td>Child</td>
+        <td>{{ child['Name'] }} - {{ getDateFormatted(child['DateOfBirth']) }} ({{ child['Relationship'] }})</td>
+      </tr>
+      {% endfor %}
+
   	  <tr>
   	    <td>Date of Birth</td>
   	    <td>{{ getDateFormatted(Claim['DateOfBirth']) }}</td>
@@ -51,7 +58,7 @@
 
   	  <tr>
   	    <td>Home Address</td>
-  	    <td>  {{ Claim['HouseNumberAndStreet'] }}<br>
+  	    <td>{{ Claim['HouseNumberAndStreet'] }}<br>
   	      {{ Claim['Town'] }}<br>
   	      {{ Claim['County'] }}<br>
   	      {{ Claim['PostCode'] }}</td>

--- a/app/views/helpers/claim-expense-helper.js
+++ b/app/views/helpers/claim-expense-helper.js
@@ -8,12 +8,9 @@ module.exports = function (expense) {
       formattedDetail = `${expense.From} to ${expense.To} for ${expense.DurationOfTravel} days`
       break
     case 'bus':
+    case 'plane':
     case 'train':
-      if (expense.IsReturn) {
-        formattedDetail = `${expense.From} to ${expense.To} - Return`
-      } else {
-        formattedDetail = `${expense.From} to ${expense.To}`
-      }
+      formattedDetail = `${addChildPrefix(expense)}${expense.From} to ${expense.To}${addReturnPostfix(expense)}`
       break
     case 'light refreshment':
       if (expense.TravelTime === 'over-five') {
@@ -26,11 +23,27 @@ module.exports = function (expense) {
       formattedDetail = `Nights stayed: ${expense.DurationOfTravel}`
       break
     case 'ferry':
-      formattedDetail = `${expense.From} to ${expense.To} as ${displayFieldNames[expense.TicketType]}`
+      formattedDetail = `${addChildPrefix(expense)}${expense.From} to ${expense.To} as ${displayFieldNames[expense.TicketType]}${addReturnPostfix(expense)}`
       break
     default:
       formattedDetail = `${expense.From} to ${expense.To}`
   }
 
   return formattedDetail
+}
+
+function addChildPrefix (expense) {
+  if (expense.IsChild) {
+    return 'Child - '
+  } else {
+    return ''
+  }
+}
+
+function addReturnPostfix (expense) {
+  if (expense.IsReturn) {
+    return ' - Return'
+  } else {
+    return ''
+  }
 }

--- a/test/e2e/spec.js
+++ b/test/e2e/spec.js
@@ -1,9 +1,8 @@
-// TODO: Will need to add check on each of the pages that has a constructed URL path.
 var moment = require('moment')
 var databaseHelper = require('../helpers/database-setup-for-tests')
 var expect = require('chai').expect
 
-// variables for creating and deleting a record
+// Variables for creating and deleting a record
 var reference = '1111111'
 var date
 var claimId
@@ -12,6 +11,8 @@ var prisonerId
 var visitorId
 var expenseId1
 var expenseId2
+var childId1
+var childId2
 
 describe('First time claim viewing flow', () => {
   before(function () {
@@ -23,6 +24,8 @@ describe('First time claim viewing flow', () => {
       visitorId = ids.visitorId
       expenseId1 = ids.expenseId1
       expenseId2 = ids.expenseId2
+      childId1 = ids.childId1
+      childId2 = ids.childId2
     })
   })
 
@@ -55,7 +58,6 @@ describe('First time claim viewing flow', () => {
   })
 
   after(function () {
-    // Clean up
-    return databaseHelper.deleteTestData(claimId, eligibilityId, visitorId, prisonerId, expenseId1, expenseId2)
+    return databaseHelper.deleteTestData(claimId, eligibilityId, visitorId, prisonerId, expenseId1, expenseId2, childId1, childId2)
   })
 })

--- a/test/helpers/database-setup-for-tests.js
+++ b/test/helpers/database-setup-for-tests.js
@@ -95,6 +95,28 @@ module.exports.insertTestData = function (reference, date, status) {
       })
       .then(function (result) {
         ids.expenseId2 = result[0]
+        return knex('IntSchema.ClaimChild')
+          .returning('ClaimChildId')
+          .insert({
+            ClaimId: ids.claimId,
+            Name: data.ClaimChild[0].Name,
+            DateOfBirth: date,
+            Relationship: data.ClaimChild[0].Relationship
+          })
+      })
+      .then(function (result) {
+        ids.childId1 = result[0]
+        return knex('IntSchema.ClaimChild')
+          .returning('ClaimChildId')
+          .insert({
+            ClaimId: ids.claimId,
+            Name: data.ClaimChild[1].Name,
+            DateOfBirth: date,
+            Relationship: data.ClaimChild[1].Relationship
+          })
+      })
+      .then(function (result) {
+        ids.childId2 = result[0]
         resolve(ids)
       })
       .catch(function (error) {
@@ -103,24 +125,28 @@ module.exports.insertTestData = function (reference, date, status) {
   })
 }
 
-module.exports.deleteTestData = function (claimId, eligibilityId, visitorId, prisonerId, expenseId1, expenseId2) {
+module.exports.deleteTestData = function (claimId, eligibilityId, visitorId, prisonerId, expenseId1, expenseId2, childId1, childId2) {
   return new Promise(function (resolve, reject) {
-    knex('IntSchema.ClaimExpense').where('ClaimExpenseId', expenseId1).del().then(function () {
-      knex('IntSchema.ClaimExpense').where('ClaimExpenseId', expenseId2).del().then(function () {
-        knex('IntSchema.Claim').where('ClaimId', claimId).del().then(function () {
-          knex('IntSchema.Visitor').where('VisitorId', visitorId).del().then(function () {
-            knex('IntSchema.Prisoner').where('PrisonerId', prisonerId).del().then(function () {
-              knex('IntSchema.Eligibility').where('EligibilityId', eligibilityId).del().then(function () {
-                resolve()
+    return knex('IntSchema.ClaimExpense').where('ClaimExpenseId', expenseId1).del().then(function () {
+      return knex('IntSchema.ClaimExpense').where('ClaimExpenseId', expenseId2).del().then(function () {
+        return knex('IntSchema.ClaimChild').where('ClaimChildId', childId1).del().then(function () {
+          return knex('IntSchema.ClaimChild').where('ClaimChildId', childId2).del().then(function () {
+            return knex('IntSchema.Claim').where('ClaimId', claimId).del().then(function () {
+              return knex('IntSchema.Visitor').where('VisitorId', visitorId).del().then(function () {
+                return knex('IntSchema.Prisoner').where('PrisonerId', prisonerId).del().then(function () {
+                  return knex('IntSchema.Eligibility').where('EligibilityId', eligibilityId).del().then(function () {
+                    resolve()
+                  })
+                })
               })
             })
           })
         })
       })
     })
-      .catch(function (error) {
-        reject(error)
-      })
+    .catch(function (error) {
+      reject(error)
+    })
   })
 }
 
@@ -156,6 +182,16 @@ module.exports.getTestData = function (reference, status) {
       ExpenseType: 'accommodation',
       Cost: '80.00',
       DurationOfTravel: 1
+    }],
+    ClaimChild: [{
+      Name: 'Jane Bloggs',
+      DateOfBirth: '01-09-2005',
+      Relationship: 'prisoners-child'
+    },
+    {
+      Name: 'Michael Bloggs',
+      DateOfBirth: '15-10-2010',
+      Relationship: 'claimants-child'
     }]
   }
 }

--- a/test/integration/services/data/test-get-claims-list-and-count.js
+++ b/test/integration/services/data/test-get-claims-list-and-count.js
@@ -12,25 +12,28 @@ var prisonerId
 var visitorId
 var expenseId1
 var expenseId2
+var childId1
+var childId2
 
 describe('services/data/get-claim-list-and-count', function () {
-  describe('module', function (done) {
-    before(function (done) {
+  describe('module', function () {
+    before(function () {
       date = moment()
       testData = databaseHelper.getTestData(reference, 'TESTING')
-      databaseHelper.insertTestData(reference, date.toDate(), 'TESTING').then(function (ids) {
+      return databaseHelper.insertTestData(reference, date.toDate(), 'TESTING').then(function (ids) {
         claimId = ids.claimId
         eligibilityId = ids.eligibilityId
         prisonerId = ids.prisonerId
         visitorId = ids.visitorId
         expenseId1 = ids.expenseId1
         expenseId2 = ids.expenseId2
-        done()
+        childId1 = ids.childId1
+        childId2 = ids.childId2
       })
     })
 
-    it('should return list of claims and total', function (done) {
-      getClaimsListAndCount('TESTING', 0, 1)
+    it('should return list of claims and total', function () {
+      return getClaimsListAndCount('TESTING', 0, 1)
         .then(function (result) {
           expect(result.claims.length).to.equal(1)
           expect(result.claims[0].Reference).to.equal(reference)
@@ -40,29 +43,33 @@ describe('services/data/get-claim-list-and-count', function () {
           expect(result.claims[0].DateSubmittedFormatted.toString()).to.equal(date.format('DD-MM-YYYY HH:mm').toString())
           expect(result.claims[0].ClaimId).to.equal(claimId)
           expect(result.total.Count).to.equal(1)
-          done()
         })
         .catch(function (error) {
           throw error
         })
     })
 
-    it('should return no data', function (done) {
-      getClaimsListAndCount('TESTING_NONE', 0, 10)
+    it('should return no data', function () {
+      return getClaimsListAndCount('TESTING_NONE', 0, 10)
         .then(function (result) {
           expect(result.total.Count).to.equal(0)
-          done()
         })
         .catch(function (error) {
           throw error
         })
     })
 
-    after(function (done) {
-      // Clean up
-      databaseHelper.deleteTestData(claimId, eligibilityId, visitorId, prisonerId, expenseId1, expenseId2).then(function () {
-        done()
-      })
+    after(function () {
+      return databaseHelper.deleteTestData(
+        claimId,
+        eligibilityId,
+        visitorId,
+        prisonerId,
+        expenseId1,
+        expenseId2,
+        childId1,
+        childId2
+      )
     })
   })
 })

--- a/test/integration/services/data/test-get-individual-claim-details.js
+++ b/test/integration/services/data/test-get-individual-claim-details.js
@@ -12,25 +12,28 @@ var prisonerId
 var visitorId
 var expenseId1
 var expenseId2
+var childId1
+var childId2
 
 describe('services/data/get-individual-claim-details', function () {
-  describe('get', function (done) {
-    before(function (done) {
+  describe('get', function () {
+    before(function () {
       testData = databaseHelper.getTestData(reference, 'Test')
       date = moment().toDate()
-      databaseHelper.insertTestData(reference, date, 'Test').then(function (ids) {
+      return databaseHelper.insertTestData(reference, date, 'Test').then(function (ids) {
         claimId = ids.claimId
         eligibilityId = ids.eligibilityId
         prisonerId = ids.prisonerId
         visitorId = ids.visitorId
         expenseId1 = ids.expenseId1
         expenseId2 = ids.expenseId2
-        done()
+        childId1 = ids.childId1
+        childId2 = ids.childId2
       })
     })
 
-    it('should return a claims details', function (done) {
-      getClaim(claimId)
+    it('should return a claims details', function () {
+      return getClaim(claimId)
         .then(function (result) {
           expect(result.claim.Reference).to.equal(reference)
           expect(result.claim.FirstName).to.equal(testData.Visitor.FirstName)
@@ -42,18 +45,25 @@ describe('services/data/get-individual-claim-details', function () {
           expect(result.claim.NameOfPrison).to.equal(testData.Prisoner.NameOfPrison)
           expect(result.claimExpenses[0].ExpenseType).to.equal(testData.ClaimExpenses[0].ExpenseType)
           expect(result.claimExpenses[1].Cost).to.equal(testData.ClaimExpenses[1].Cost)
-          done()
+          expect(result.claimChild[0].Name).to.equal(testData.ClaimChild[0].Name)
+          expect(result.claimChild[1].Name).to.equal(testData.ClaimChild[1].Name)
         })
         .catch(function (error) {
           throw error
         })
     })
 
-    after(function (done) {
-      // Clean up
-      databaseHelper.deleteTestData(claimId, eligibilityId, visitorId, prisonerId, expenseId1, expenseId2).then(function () {
-        done()
-      })
+    after(function () {
+      return databaseHelper.deleteTestData(
+        claimId,
+        eligibilityId,
+        visitorId,
+        prisonerId,
+        expenseId1,
+        expenseId2,
+        childId1,
+        childId2
+      )
     })
   })
 })

--- a/test/integration/services/data/test-insert-task-send-claim-notification.js
+++ b/test/integration/services/data/test-insert-task-send-claim-notification.js
@@ -17,6 +17,8 @@ var prisonerId
 var visitorId
 var expenseId1
 var expenseId2
+var childId1
+var childId2
 
 describe('services/data/insert-task-send-first-time-claim-notification', function () {
   before(function () {
@@ -29,6 +31,8 @@ describe('services/data/insert-task-send-first-time-claim-notification', functio
       visitorId = ids.visitorId
       expenseId1 = ids.expenseId1
       expenseId2 = ids.expenseId2
+      childId1 = ids.childId1
+      childId2 = ids.childId2
     })
   })
 
@@ -49,7 +53,16 @@ describe('services/data/insert-task-send-first-time-claim-notification', functio
 
   after(function () {
     return knex('IntSchema.Task').where({Reference: reference, ClaimId: claimId}).del().then(function () {
-      return databaseHelper.deleteTestData(claimId, eligibilityId, visitorId, prisonerId, expenseId1, expenseId2)
+      return databaseHelper.deleteTestData(
+        claimId,
+        eligibilityId,
+        visitorId,
+        prisonerId,
+        expenseId1,
+        expenseId2,
+        childId1,
+        childId2
+      )
     })
   })
 })

--- a/test/integration/services/data/test-submit-claim-response.js
+++ b/test/integration/services/data/test-submit-claim-response.js
@@ -21,7 +21,16 @@ var newIds = {}
 describe('services/data/submit-claim-response', function () {
   before(function () {
     return databaseHelper.insertTestData(reference, moment().toDate(), 'NEW').then(function (ids) {
-      newIds = {'claimId': ids.claimId, 'eligibilityId': ids.eligibilityId, 'prisonerId': ids.prisonerId, 'visitorId': ids.visitorId, 'expenseId1': ids.expenseId1, 'expenseId2': ids.expenseId2}
+      newIds = {
+        claimId: ids.claimId,
+        eligibilityId: ids.eligibilityId,
+        prisonerId: ids.prisonerId,
+        visitorId: ids.visitorId,
+        expenseId1: ids.expenseId1,
+        expenseId2: ids.expenseId2,
+        childId1: ids.childId1,
+        childId2: ids.childId2
+      }
     })
   })
 
@@ -68,6 +77,15 @@ describe('services/data/submit-claim-response', function () {
   })
 
   after(function () {
-    return databaseHelper.deleteTestData(newIds.claimId, newIds.eligibilityId, newIds.visitorId, newIds.prisonerId, newIds.expenseId1, newIds.expenseId2)
+    return databaseHelper.deleteTestData(
+      newIds.claimId,
+      newIds.eligibilityId,
+      newIds.visitorId,
+      newIds.prisonerId,
+      newIds.expenseId1,
+      newIds.expenseId2,
+      newIds.childId1,
+      newIds.childId2
+    )
   })
 })

--- a/test/unit/views/helpers/test-claim-expense-helper.js
+++ b/test/unit/views/helpers/test-claim-expense-helper.js
@@ -1,23 +1,68 @@
 var expect = require('chai').expect
-var getExpenseFormatted = require('../../../../app/views/helpers/claim-expense-helper')
+var claimExpenseHelper = require('../../../../app/views/helpers/claim-expense-helper')
 
 describe('views/claim-expense-helper', function () {
-  describe('format expense', function () {
-    it('should format expense type to return string of expense details', function () {
-      var data = [
-        {
-          ExpenseType: 'bus',
-          IsReturn: true,
-          From: 'Test',
-          To: 'Test2'
-        },
-        {
-          ExpenseType: 'accommodation',
-          DurationOfTravel: 2
-        }
-      ]
-      expect(getExpenseFormatted(data[0])).to.equal('Test to Test2 - Return')
-      expect(getExpenseFormatted(data[1])).to.equal('Nights stayed: 2')
+  describe('FormattedDetail', function () {
+    const FROM = 'PointA'
+    const TO = 'PointB'
+    const DURATION_OF_TRAVEL = '2'
+    const TICKET_TYPE = 'foot-passenger'
+
+    const CHILD_PREFIX = 'Child - '
+    const RETURN_POSTFIX = ' - Return'
+
+    it('should return formatted detail string for ClaimExpense', function () {
+      expect(claimExpenseHelper({ ExpenseType: 'car hire', From: FROM, To: TO, DurationOfTravel: 2 }))
+        .to.equal(`${FROM} to ${TO} for ${DURATION_OF_TRAVEL} days`)
+
+      expect(claimExpenseHelper({ ExpenseType: 'bus', From: FROM, To: TO }))
+        .to.equal(`${FROM} to ${TO}`)
+
+      expect(claimExpenseHelper({ ExpenseType: 'train', From: FROM, To: TO }))
+        .to.equal(`${FROM} to ${TO}`)
+
+      expect(claimExpenseHelper({ ExpenseType: 'light refreshment', TravelTime: 'over-five' }))
+        .to.equal('Over five hours away but under ten hours')
+
+      expect(claimExpenseHelper({ ExpenseType: 'light refreshment', TravelTime: 'over-ten' }))
+        .to.equal('Over ten hours away')
+
+      expect(claimExpenseHelper({ ExpenseType: 'accommodation', DurationOfTravel: DURATION_OF_TRAVEL }))
+        .to.equal(`Nights stayed: ${DURATION_OF_TRAVEL}`)
+
+      expect(claimExpenseHelper({ ExpenseType: 'ferry', From: FROM, To: TO, TicketType: TICKET_TYPE }))
+        .to.equal(`${FROM} to ${TO} as a foot passenger`)
+
+      expect(claimExpenseHelper({ ExpenseType: 'anything-else', From: FROM, To: TO }))
+        .to.equal(`${FROM} to ${TO}`)
+    })
+
+    it('should prepend child prefix for bus, train, plane, and ferry expenses', function () {
+      expect(claimExpenseHelper({ ExpenseType: 'bus', From: FROM, To: TO, IsChild: true }))
+        .to.equal(`${CHILD_PREFIX}${FROM} to ${TO}`)
+
+      expect(claimExpenseHelper({ ExpenseType: 'train', From: FROM, To: TO, IsChild: true }))
+        .to.equal(`${CHILD_PREFIX}${FROM} to ${TO}`)
+
+      expect(claimExpenseHelper({ ExpenseType: 'plane', From: FROM, To: TO, IsChild: true }))
+        .to.equal(`${CHILD_PREFIX}${FROM} to ${TO}`)
+
+      expect(claimExpenseHelper({ ExpenseType: 'ferry', From: FROM, To: TO, IsChild: true, TicketType: TICKET_TYPE }))
+        .to.equal(`${CHILD_PREFIX}${FROM} to ${TO} as a foot passenger`)
+    })
+
+    it('should append return postfix for bus, train, plane, and ferry expenses', function () {
+      expect(claimExpenseHelper({ ExpenseType: 'bus', From: FROM, To: TO, IsReturn: true }))
+        .to.equal(`${FROM} to ${TO}${RETURN_POSTFIX}`)
+
+      expect(claimExpenseHelper({ ExpenseType: 'train', From: FROM, To: TO, IsReturn: true }))
+        .to.equal(`${FROM} to ${TO}${RETURN_POSTFIX}`)
+
+      expect(claimExpenseHelper({ ExpenseType: 'plane', From: FROM, To: TO, IsReturn: true }))
+        .to.equal(`${FROM} to ${TO}${RETURN_POSTFIX}`)
+
+      expect(claimExpenseHelper({ ExpenseType: 'ferry', From: FROM, To: TO, IsReturn: true, TicketType: TICKET_TYPE }))
+        .to.equal(`${FROM} to ${TO} as a foot passenger${RETURN_POSTFIX}`)
     })
   })
 })


### PR DESCRIPTION
view-claim updated:
- Now displays children details (name, relationship, date of birth).
- Expenses now distinguish between child and adult expenses.
- Updated tests. 
- Updated test helpers.
- Removed done from altered tests.

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
