### PR TITLE
Chore/approve differnet amount fixes

### DIFF
--- a/app/routes/helpers/merge-claim-expenses-with-submitted-responses.js
+++ b/app/routes/helpers/merge-claim-expenses-with-submitted-responses.js
@@ -13,7 +13,8 @@ module.exports = function (oldData, nonPersistedData) {
     expense.Status = postedClaimExpenseResponse.status
     if (expense.Status === 'APPROVED-DIFF-AMOUNT') {
       expense.ApprovedCost = postedClaimExpenseResponse.approvedCost
-      if (!Validator.isCurrency(postedClaimExpenseResponse.approvedCost)) {
+      if (!Validator.isCurrency(postedClaimExpenseResponse.approvedCost) || !Validator.isGreaterThanZero(postedClaimExpenseResponse.approvedCost) ||
+        !Validator.isLessThanMaximumDifferentApprovedAmount(postedClaimExpenseResponse.approvedCost)) {
         expense.Error = true
       }
     }

--- a/app/services/data/get-individual-claim-details.js
+++ b/app/services/data/get-individual-claim-details.js
@@ -79,6 +79,9 @@ module.exports = function (claimId) {
                 if (expense.ApprovedCost !== null) {
                   expense.ApprovedCost = Number(expense.ApprovedCost).toFixed(2)
                 }
+                if (expense.ExpenseType === 'car' && expense.Status === null) {
+                  expense.Status = 'APPROVED-DIFF-AMOUNT'
+                }
               })
               claim.Total = Number(total).toFixed(2)
               return claimExpenses

--- a/app/services/domain/claim-decision.js
+++ b/app/services/domain/claim-decision.js
@@ -69,6 +69,7 @@ class ClaimDecision {
           .isRequired()
           .isCurrency()
           .isGreaterThanZero()
+          .isLessThanMaximumDifferentApprovedAmount()
       }
     })
 

--- a/app/services/validators/common-validator.js
+++ b/app/services/validators/common-validator.js
@@ -20,6 +20,6 @@ exports.isGreaterThanZero = function (value) {
   return value > 0
 }
 
-exports.isLessThanMaximumDifferentApproved = function (value) {
+exports.isLessThanMaximumDifferentApprovedAmount = function (value) {
   return value <= 250 && value !== null
 }

--- a/app/services/validators/common-validator.js
+++ b/app/services/validators/common-validator.js
@@ -1,3 +1,4 @@
+const config = require('../../../config')
 /**
  * This file defines all generic validation tests used in the application. This file can and should be used by the
  * three higher level validators: FieldValidator, FieldSetValidator, and UrlPathValidator.
@@ -21,5 +22,5 @@ exports.isGreaterThanZero = function (value) {
 }
 
 exports.isLessThanMaximumDifferentApprovedAmount = function (value) {
-  return value <= 250 && value !== null
+  return value <= parseInt(config.MAX_APPROVED_DIFFERENT_AMOUNT) && value !== null
 }

--- a/app/services/validators/common-validator.js
+++ b/app/services/validators/common-validator.js
@@ -19,3 +19,7 @@ exports.isCurrency = function (value) {
 exports.isGreaterThanZero = function (value) {
   return value > 0
 }
+
+exports.isLessThanMaximumDifferentApproved = function (value) {
+  return value <= 250 && value !== null
+}

--- a/app/services/validators/field-validator.js
+++ b/app/services/validators/field-validator.js
@@ -48,6 +48,13 @@ class FieldValidator {
     }
     return this
   }
+
+  isLessThanMaximumDifferentApprovedAmount () {
+    if (!validator.isLessThanMaximumDifferentApprovedAmount(this.data)) {
+      this.errors.add(this.fieldName, ERROR_MESSAGES.getIsLessThanMaximumDifferentApprovedAmount)
+    }
+    return this
+  }
 }
 
 module.exports = function (data, fieldName, errors) {

--- a/app/services/validators/validation-error-messages.js
+++ b/app/services/validators/validation-error-messages.js
@@ -8,5 +8,6 @@ module.exports = {
   getAssistedDigitalCaseworkerSameClaim: 'You cannot process this claim since you filled it in on behalf of a visitor',
   getUploadTooLarge: 'File uploaded too large',
   getUploadIncorrectType: 'File uploaded was not an image or pdf',
-  getUpdateConflict: function (currentStatus) { return `This record has been updated since you started viewing it, its current status is ${currentStatus}` }
+  getUpdateConflict: function (currentStatus) { return `This record has been updated since you started viewing it, its current status is ${currentStatus}` },
+  getIsLessThanMaximumDifferentApprovedAmount: function (displayName) { return `${displayName} can only be £250 or less` }
 }

--- a/config.js
+++ b/config.js
@@ -35,5 +35,8 @@ module.exports = {
   FILE_UPLOAD_MAXSIZE: process.env.FILE_UPLOAD_MAXSIZE || '5242880', // 5MB in Bytes.
 
   // Assisted Digital external link
-  EXTERNAL_SERVICE_URL: process.env.APVS_EXTERNAL_SERVICE_URL || 'http://localhost:3000'
+  EXTERNAL_SERVICE_URL: process.env.APVS_EXTERNAL_SERVICE_URL || 'http://localhost:3000',
+
+  // Value configurations
+  MAX_APPROVED_DIFFERENT_AMOUNT: process.env.MAX_APPROVED_DIFFERENT_AMOUNT || '250'
 }

--- a/test/unit/services/validators/test-common-validator.js
+++ b/test/unit/services/validators/test-common-validator.js
@@ -178,4 +178,53 @@ describe('services/validators/common-validator', function () {
       done()
     })
   })
+
+  describe('isLessThanMaximumDifferentApproved', function () {
+    const VALID_NUMERIC = '20'
+    const VALID_FLOAT = '7.99'
+    const INVALID_NUMERIC = '1000'
+    const INVALID_STRING = 'some invalid string'
+
+    it('should return false if passed null', function (done) {
+      var result = validator.isLessThanMaximumDifferentApproved(null)
+      expect(result).to.equal(false)
+      done()
+    })
+
+    it('should return false if passed undefined', function (done) {
+      var result = validator.isLessThanMaximumDifferentApproved(undefined)
+      expect(result).to.equal(false)
+      done()
+    })
+
+    it('should return false if passed an object', function (done) {
+      var result = validator.isLessThanMaximumDifferentApproved({})
+      expect(result).to.equal(false)
+      done()
+    })
+
+    it('should return true if passed a numeric string that is greater than zero', function (done) {
+      var result = validator.isLessThanMaximumDifferentApproved(VALID_NUMERIC)
+      expect(result).to.equal(true)
+      done()
+    })
+
+    it('should return true if passed a float that is greater than zero', function (done) {
+      var result = validator.isLessThanMaximumDifferentApproved(VALID_FLOAT)
+      expect(result).to.equal(true)
+      done()
+    })
+
+    it('should return false if passed a negative numeric string', function (done) {
+      var result = validator.isLessThanMaximumDifferentApproved(INVALID_NUMERIC)
+      expect(result).to.equal(false)
+      done()
+    })
+
+    it('should return false if passed a non-numeric string', function (done) {
+      var result = validator.isLessThanMaximumDifferentApproved(INVALID_STRING)
+      expect(result).to.equal(false)
+      done()
+    })
+  })
 })

--- a/test/unit/services/validators/test-common-validator.js
+++ b/test/unit/services/validators/test-common-validator.js
@@ -179,50 +179,50 @@ describe('services/validators/common-validator', function () {
     })
   })
 
-  describe('isLessThanMaximumDifferentApproved', function () {
+  describe('isLessThanMaximumDifferentApprovedAmount', function () {
     const VALID_NUMERIC = '20'
     const VALID_FLOAT = '7.99'
     const INVALID_NUMERIC = '1000'
     const INVALID_STRING = 'some invalid string'
 
     it('should return false if passed null', function (done) {
-      var result = validator.isLessThanMaximumDifferentApproved(null)
+      var result = validator.isLessThanMaximumDifferentApprovedAmount(null)
       expect(result).to.equal(false)
       done()
     })
 
     it('should return false if passed undefined', function (done) {
-      var result = validator.isLessThanMaximumDifferentApproved(undefined)
+      var result = validator.isLessThanMaximumDifferentApprovedAmount(undefined)
       expect(result).to.equal(false)
       done()
     })
 
     it('should return false if passed an object', function (done) {
-      var result = validator.isLessThanMaximumDifferentApproved({})
+      var result = validator.isLessThanMaximumDifferentApprovedAmount({})
       expect(result).to.equal(false)
       done()
     })
 
     it('should return true if passed a numeric string that is greater than zero', function (done) {
-      var result = validator.isLessThanMaximumDifferentApproved(VALID_NUMERIC)
+      var result = validator.isLessThanMaximumDifferentApprovedAmount(VALID_NUMERIC)
       expect(result).to.equal(true)
       done()
     })
 
     it('should return true if passed a float that is greater than zero', function (done) {
-      var result = validator.isLessThanMaximumDifferentApproved(VALID_FLOAT)
+      var result = validator.isLessThanMaximumDifferentApprovedAmount(VALID_FLOAT)
       expect(result).to.equal(true)
       done()
     })
 
     it('should return false if passed a negative numeric string', function (done) {
-      var result = validator.isLessThanMaximumDifferentApproved(INVALID_NUMERIC)
+      var result = validator.isLessThanMaximumDifferentApprovedAmount(INVALID_NUMERIC)
       expect(result).to.equal(false)
       done()
     })
 
     it('should return false if passed a non-numeric string', function (done) {
-      var result = validator.isLessThanMaximumDifferentApproved(INVALID_STRING)
+      var result = validator.isLessThanMaximumDifferentApprovedAmount(INVALID_STRING)
       expect(result).to.equal(false)
       done()
     })

--- a/test/unit/services/validators/test-field-validator.js
+++ b/test/unit/services/validators/test-field-validator.js
@@ -207,4 +207,54 @@ describe('services/validators/field-validator', function () {
       done()
     })
   })
+
+  describe('isLessThanMaximumDifferentApprovedAmount', function () {
+    const VALID_INPUT = '20'
+    const INVALID_INPUT = '300'
+
+    it('should return an error object if passed null', function (done) {
+      var errorHandler = ErrorHandler()
+      FieldValidator(null, FIELD_NAME, errorHandler)
+        .isLessThanMaximumDifferentApprovedAmount()
+      var errors = errorHandler.get()
+      expect(errors).to.have.property(FIELD_NAME)
+      done()
+    })
+
+    it('should return an error object if passed undefined', function (done) {
+      var errorHandler = ErrorHandler()
+      FieldValidator(undefined, FIELD_NAME, errorHandler)
+        .isLessThanMaximumDifferentApprovedAmount()
+      var errors = errorHandler.get()
+      expect(errors).to.have.property(FIELD_NAME)
+      done()
+    })
+
+    it('should return an error object if passed an object', function (done) {
+      var errorHandler = ErrorHandler()
+      FieldValidator({}, FIELD_NAME, errorHandler)
+        .isLessThanMaximumDifferentApprovedAmount()
+      var errors = errorHandler.get()
+      expect(errors).to.have.property(FIELD_NAME)
+      done()
+    })
+
+    it('should return false if passed a numeric value greater than zero', function (done) {
+      var errorHandler = ErrorHandler()
+      FieldValidator(VALID_INPUT, FIELD_NAME, errorHandler)
+        .isLessThanMaximumDifferentApprovedAmount()
+      var errors = errorHandler.get()
+      expect(errors).to.equal(false)
+      done()
+    })
+
+    it('should return an error object if passed a value greater than 250', function (done) {
+      var errorHandler = ErrorHandler()
+      FieldValidator(INVALID_INPUT, FIELD_NAME, errorHandler)
+        .isLessThanMaximumDifferentApprovedAmount()
+      var errors = errorHandler.get()
+      expect(errors).to.have.property(FIELD_NAME)
+      done()
+    })
+  })
 })


### PR DESCRIPTION
Fixed issues of car journey needing approve different amount, warning not always displaying and a check for maximum amount that can be approved
 
* Change status of car journeys to auto to approve different amount if they have no previous status
* Added validation for a maximum amount of £250 to approve different amount
* Added additions to warning for approve different amount

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
