### PR TITLE
chore - run ie8 tests on Windows XP

### DIFF
--- a/test/wdio.conf.sauce.ie8.jenkins.js
+++ b/test/wdio.conf.sauce.ie8.jenkins.js
@@ -9,7 +9,7 @@ exports.config = {
   capabilities: [{
     maxInstances: 1,
     browserName: 'internet explorer',
-    platform: 'Windows 7',
+    platform: 'Windows XP',
     version: '8.0'
   }],
   sync: false,

--- a/test/wdio.conf.sauce.ie8.js
+++ b/test/wdio.conf.sauce.ie8.js
@@ -10,7 +10,7 @@ exports.config = {
   capabilities: [{
     maxInstances: 1,
     browserName: 'internet explorer',
-    platform: 'Windows 7',
+    platform: 'Windows XP',
     version: '8.0'
   }],
   sync: false,


### PR DESCRIPTION
chore - run ie8 tests on Windows XP
 
Fixes ie8 e2e test

## Checklist

- [ ] Unit tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
