### PR TITLE
Chore/Date reviewed

### DIFF
--- a/app/services/data/submit-claim-response.js
+++ b/app/services/data/submit-claim-response.js
@@ -42,6 +42,7 @@ function updateClaim (claimId, caseworker, decision, reason, note, visitConfirma
     'Reason': reason,
     'Note': note,
     'VisitConfirmationCheck': visitConfirmationCheck,
+    'DateReviewed': moment().toDate(),
     'LastUpdated': moment().toDate()
   })
 }

--- a/migrations/20161201133531_add_date_reviewed_column.js
+++ b/migrations/20161201133531_add_date_reviewed_column.js
@@ -1,0 +1,11 @@
+exports.up = function (knex, Promise) {
+  return knex.schema.table('Claim', function (table) {
+    table.dateTime('DateReviewed')
+  })
+}
+
+exports.down = function (knex, Promise) {
+  return knex.schema.table('Claim', function (table) {
+    table.dropColumn('DateReviewed')
+  })
+}

--- a/test/integration/services/data/test-submit-claim-response.js
+++ b/test/integration/services/data/test-submit-claim-response.js
@@ -51,6 +51,9 @@ describe('services/data/submit-claim-response', function () {
         {'claimExpenseId': newIds.expenseId2, 'approvedCost': '20', 'status': claimDecisionEnum.REQUEST_INFORMATION}
       ]
     }
+    var currentDate = new Date()
+    var twoMinutesAgo = new Date().setMinutes(currentDate.getMinutes() - 2)
+    var twoMinutesAhead = new Date().setMinutes(currentDate.getMinutes() + 2)
 
     return submitClaimResponse(claimId, claimResponse)
       .then(function (result) {
@@ -67,8 +70,8 @@ describe('services/data/submit-claim-response', function () {
             expect(result.Note).to.be.equal(claimResponse.note)
             expect(result.NomisCheck).to.be.equal(claimDecisionEnum.REJECTED)
             expect(result.DWPCheck).to.be.equal(claimDecisionEnum.REJECTED)
-            expect(result.LastUpdated).to.not.be.null
-            expect(result.DateReviewed).to.not.be.null
+            expect(result.LastUpdated).to.be.within(twoMinutesAgo, twoMinutesAhead)
+            expect(result.DateReviewed).to.be.within(twoMinutesAgo, twoMinutesAhead)
 
             expect(stubInsertClaimEvent.calledWith(reference, newIds.eligibilityId, newIds.claimId, `CLAIM-${claimDecisionEnum.REJECTED}`, null, claimResponse.note, caseworker, false)).to.be.true
             expect(stubInsertTaskSendClaimNotification.calledWith(tasksEnum.REJECT_CLAIM_NOTIFICATION, reference, newIds.eligibilityId, newIds.claimId)).to.be.true

--- a/test/integration/services/data/test-submit-claim-response.js
+++ b/test/integration/services/data/test-submit-claim-response.js
@@ -67,6 +67,8 @@ describe('services/data/submit-claim-response', function () {
             expect(result.Note).to.be.equal(claimResponse.note)
             expect(result.NomisCheck).to.be.equal(claimDecisionEnum.REJECTED)
             expect(result.DWPCheck).to.be.equal(claimDecisionEnum.REJECTED)
+            expect(result.LastUpdated).to.not.be.null
+            expect(result.DateReviewed).to.not.be.null
 
             expect(stubInsertClaimEvent.calledWith(reference, newIds.eligibilityId, newIds.claimId, `CLAIM-${claimDecisionEnum.REJECTED}`, null, claimResponse.note, caseworker, false)).to.be.true
             expect(stubInsertTaskSendClaimNotification.calledWith(tasksEnum.REJECT_CLAIM_NOTIFICATION, reference, newIds.eligibilityId, newIds.claimId)).to.be.true


### PR DESCRIPTION
Added DateReviewed column to Claim table.  Will get set when case worker submits a claim decision.  Same change to be made on async worker to do the same for auto-approved claims (there is another issue open for this).

Closes issue #111 