### PR TITLE
Feature/apvs 861/hc3 deductions

### DIFF
--- a/app/constants/deduction-type-enum.js
+++ b/app/constants/deduction-type-enum.js
@@ -1,0 +1,10 @@
+module.exports = {
+  HC3_DEDUCTION: {
+    value: 'hc3',
+    displayName: 'HC3'
+  },
+  OVERPAYMENT: {
+    value: 'overpayment',
+    displayName: 'Overpayment'
+  }
+}

--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -15,29 +15,14 @@ const displayHelper = require('../../views/helpers/display-helper')
 const mergeClaimExpensesWithSubmittedResponses = require('../helpers/merge-claim-expenses-with-submitted-responses')
 const getLastUpdated = require('../../services/data/get-claim-last-updated')
 const checkLastUpdated = require('../../services/check-last-updated')
+const insertDeduction = require('../../services/data/insert-deduction')
+const disableDeduction = require('../../services/data/disable-deduction')
 
 module.exports = function (router) {
   router.get('/claim/:claimId', function (req, res) {
     authorisation.isCaseworker(req)
 
-    getIndividualClaimDetails(req.params.claimId)
-      .then(function (data) {
-        return res.render('./claim/view-claim', {
-          title: 'APVS Claim',
-          Claim: data.claim,
-          Expenses: data.claimExpenses,
-          Children: data.claimChild,
-          getDateFormatted: getDateFormatted,
-          getClaimExpenseDetailFormatted: getClaimExpenseDetailFormatted,
-          getChildFormatted: getChildFormatted,
-          getDisplayFieldName: getDisplayFieldName,
-          prisonerRelationshipsEnum: prisonerRelationshipsEnum,
-          receiptRequiredEnum: receiptRequiredEnum,
-          displayHelper: displayHelper,
-          duplicates: data.duplicates,
-          claimEvents: data.claimEvents
-        })
-      })
+    renderViewClaimPage(req.params.claimId, res)
   })
 
   router.post('/claim/:claimId', function (req, res) {
@@ -49,26 +34,23 @@ module.exports = function (router) {
         if (updateConflict) {
           throw new ValidationError({UpdateConflict: [ValidationErrorMessages.getUpdateConflict(lastUpdatedData.Status)]})
         }
-        var claimExpenses = getClaimExpenseResponses(req.body)
-        var claimDecision = new ClaimDecision(
-          req.user.email,
-          req.body.assistedDigitalCaseworker,
-          req.body.decision,
-          req.body.reasonRequest,
-          req.body.reasonReject,
-          req.body.additionalInfoApprove,
-          req.body.additionalInfoRequest,
-          req.body.additionalInfoReject,
-          req.body.nomisCheck,
-          req.body.dwpCheck,
-          req.body.visitConfirmationCheck,
-          claimExpenses
-        )
 
-        SubmitClaimResponse(req.params.claimId, claimDecision)
-          .then(function () {
-            return res.redirect('/')
-          })
+        var removeDeductionClicked = false
+
+        Object.keys(req.body).forEach(function (key) {
+          if (key.indexOf('remove-deduction') > -1) {
+            removeDeductionClicked = true
+          }
+        })
+
+        if (req.body['add-deduction']) {
+          return addDeduction(req, res)
+        } else if (removeDeductionClicked) {
+          return removeDeduction(req, res)
+        } else {
+          var claimExpenses = getClaimExpenseResponses(req.body)
+          return submitClaimDecision(req, res, claimExpenses)
+        }
       } catch (error) {
         if (error instanceof ValidationError) {
           getIndividualClaimDetails(req.params.claimId)
@@ -89,6 +71,7 @@ module.exports = function (router) {
                 prisonerRelationshipsEnum: prisonerRelationshipsEnum,
                 displayHelper: displayHelper,
                 claimDecision: req.body,
+                deductions: data.deductions,
                 errors: error.validationErrors
               })
             })
@@ -109,4 +92,74 @@ module.exports = function (router) {
       throw new Error('No path to file provided')
     }
   })
+}
+
+function removeDeduction (req, res) {
+  var deductionId
+
+  Object.keys(req.body).forEach(function (key) {
+    if (key.indexOf('remove-deduction') > -1) {
+      deductionId = key.substring(key.lastIndexOf('-') + 1)
+    }
+  })
+
+  return disableDeduction(deductionId)
+    .then(function () {
+      renderViewClaimPage(req.params.claimId, res)
+    })
+}
+
+function addDeduction (req, res) {
+  // TODO: Validation
+  var deductionType = req.body.deductionType
+  var amount = Number(req.body.deductionAmount).toFixed(2)
+
+  return insertDeduction(req.params.claimId, deductionType, amount)
+    .then(function () {
+      renderViewClaimPage(req.params.claimId, res)
+    })
+}
+
+function submitClaimDecision (req, res, claimExpenses) {
+  var claimDecision = new ClaimDecision(
+    req.user.email,
+    req.body.assistedDigitalCaseworker,
+    req.body.decision,
+    req.body.reasonRequest,
+    req.body.reasonReject,
+    req.body.additionalInfoApprove,
+    req.body.additionalInfoRequest,
+    req.body.additionalInfoReject,
+    req.body.nomisCheck,
+    req.body.dwpCheck,
+    req.body.visitConfirmationCheck,
+    claimExpenses
+  )
+
+  SubmitClaimResponse(req.params.claimId, claimDecision)
+    .then(function () {
+      return res.redirect('/')
+    })
+}
+
+function renderViewClaimPage (claimId, res) {
+  getIndividualClaimDetails(claimId)
+    .then(function (data) {
+      return res.render('./claim/view-claim', {
+        title: 'APVS Claim',
+        Claim: data.claim,
+        Expenses: data.claimExpenses,
+        Children: data.claimChild,
+        getDateFormatted: getDateFormatted,
+        getClaimExpenseDetailFormatted: getClaimExpenseDetailFormatted,
+        getChildFormatted: getChildFormatted,
+        getDisplayFieldName: getDisplayFieldName,
+        prisonerRelationshipsEnum: prisonerRelationshipsEnum,
+        receiptRequiredEnum: receiptRequiredEnum,
+        displayHelper: displayHelper,
+        duplicates: data.duplicates,
+        claimEvents: data.claimEvents,
+        deductions: data.deductions
+      })
+    })
 }

--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -99,7 +99,7 @@ module.exports = function (router) {
 function removeDeduction (req, res, deductionId) {
   return disableDeduction(deductionId)
     .then(function () {
-      return res.redirect(req.get('referrer'))
+      return res.redirect(`/claim/${req.params.claimId}`)
     })
 }
 
@@ -121,7 +121,7 @@ function addDeduction (req, res) {
 
   return insertDeduction(req.params.claimId, claimDeduction)
     .then(function () {
-      return res.redirect(req.get('referrer'))
+      return res.redirect(`/claim/${req.params.claimId}`)
     })
 }
 

--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -17,6 +17,7 @@ const getLastUpdated = require('../../services/data/get-claim-last-updated')
 const checkLastUpdated = require('../../services/check-last-updated')
 const insertDeduction = require('../../services/data/insert-deduction')
 const disableDeduction = require('../../services/data/disable-deduction')
+const ClaimDeduction = require('../../services/domain/claim-deduction')
 
 module.exports = function (router) {
   router.get('/claim/:claimId', function (req, res) {
@@ -110,11 +111,11 @@ function removeDeduction (req, res) {
 }
 
 function addDeduction (req, res) {
-  // TODO: Validation
   var deductionType = req.body.deductionType
   var amount = Number(req.body.deductionAmount).toFixed(2)
+  var claimDeduction = new ClaimDeduction(deductionType, amount)
 
-  return insertDeduction(req.params.claimId, deductionType, amount)
+  return insertDeduction(req.params.claimId, claimDeduction.deductionType, claimDeduction.amount)
     .then(function () {
       renderViewClaimPage(req.params.claimId, res)
     })

--- a/app/services/data/disable-deduction.js
+++ b/app/services/data/disable-deduction.js
@@ -1,0 +1,10 @@
+const config = require('../../../knexfile').intweb
+const knex = require('knex')(config)
+
+module.exports = function (deductionId) {
+  return knex('ClaimDeduction')
+    .where('ClaimDeductionId', deductionId)
+    .update({
+      IsEnabled: false
+    })
+}

--- a/app/services/data/disable-deduction.js
+++ b/app/services/data/disable-deduction.js
@@ -4,6 +4,7 @@ const knex = require('knex')(config)
 module.exports = function (deductionId) {
   return knex('ClaimDeduction')
     .where('ClaimDeductionId', deductionId)
+    .returning('ClaimDeductionId')
     .update({
       IsEnabled: false
     })

--- a/app/services/data/get-individual-claim-details.js
+++ b/app/services/data/get-individual-claim-details.js
@@ -1,11 +1,59 @@
 const config = require('../../../knexfile').intweb
 const knex = require('knex')(config)
 const duplicateClaimCheck = require('./duplicate-claim-check')
+const getClaimTotalAmount = require('../get-claim-total-amount')
 const moment = require('moment')
 
 module.exports = function (claimId) {
+  var claim
+  var claimExpenses
+  var claimChildren
+  var claimDeductions
+  var claimDuplicatesExist
   var claimDetails
 
+  return getClaimantDetails(claimId)
+    .then(function (claimData) {
+      claim = claimData
+      claim.lastUpdatedHidden = moment(claim.LastUpdated)
+      return getClaimDocuments(claimId)
+    })
+    .then(function (claimDocumentData) {
+      claim = appendClaimDocumentsToClaim(claim, claimDocumentData)
+      return getClaimExpenses(claimId)
+    })
+    .then(function (claimExpenseData) {
+      claimExpenses = claimExpenseData
+      return getClaimDeductions(claimId)
+    })
+    .then(function (claimDeductionData) {
+      claimDeductions = claimDeductionData
+      claim.Total = getClaimTotalAmount(claimExpenses, claimDeductionData)
+      return getClaimChildren(claimId)
+    })
+    .then(function (claimChildData) {
+      claimChildren = claimChildData
+      return duplicateClaimCheck(claimId, claim.NationalInsuranceNumber, claim.PrisonNumber, claim.DateOfJourney)
+    })
+    .then(function (result) {
+      claimDuplicatesExist = result
+      return getClaimEvents(claimId)
+    })
+    .then(function (claimEvents) {
+      claimDetails = {
+        claim: claim,
+        claimExpenses: setClaimExpenseStatusForCarJourneys(claimExpenses),
+        claimChild: claimChildren,
+        claimEvents: claimEvents,
+        deductions: claimDeductions,
+        duplicates: claimDuplicatesExist
+      }
+
+      return claimDetails
+    })
+}
+
+function getClaimantDetails (claimId) {
   return knex('Claim')
     .join('Eligibility', 'Claim.EligibilityId', '=', 'Eligibility.EligibilityId')
     .join('Visitor', 'Eligibility.EligibilityId', '=', 'Visitor.EligibilityId')
@@ -41,92 +89,70 @@ module.exports = function (claimId) {
       'Prisoner.NomisCheck',
       'Claim.VisitConfirmationCheck',
       'Claim.LastUpdated')
-    .then(function (claim) {
-      claim.lastUpdatedHidden = moment(claim.LastUpdated)
-      return knex('ClaimDocument')
-        .where({'ClaimDocument.ClaimId': claimId, 'ClaimDocument.IsEnabled': true, 'ClaimDocument.ClaimExpenseId': null})
-        .select(
-          'ClaimDocument.ClaimDocumentId',
-          'ClaimDocument.DocumentStatus',
-          'ClaimDocument.Filepath',
-          'ClaimDocument.DocumentType')
-        .orderBy('ClaimDocument.DateSubmitted', 'desc')
-        .then(function (claimDocuments) {
-          claim.benefitDocument = []
-          claimDocuments.forEach(function (document) {
-            if (document.DocumentType === 'VISIT-CONFIRMATION') {
-              claim.visitConfirmation = document
-            } else {
-              claim.benefitDocument.push(document)
-            }
-          })
-          return knex('Claim')
-            .join('ClaimExpense', 'Claim.ClaimId', '=', 'ClaimExpense.ClaimId')
-            .where('Claim.ClaimId', claimId)
-            .select('ClaimExpense.*', 'ClaimDocument.DocumentStatus', 'ClaimDocument.DocumentType', 'ClaimDocument.ClaimDocumentId', 'ClaimDocument.Filepath')
-            .leftJoin('ClaimDocument', function () {
-              this
-                .on('ClaimExpense.ClaimId', 'ClaimDocument.ClaimId')
-                .on('ClaimExpense.ClaimExpenseId', 'ClaimDocument.ClaimExpenseId')
-                .on('ClaimExpense.IsEnabled', 'ClaimDocument.IsEnabled')
-            })
-            .orderBy('ClaimExpense.ClaimExpenseId')
-            .then(function (claimExpenses) {
-              var total = 0
-              claimExpenses.forEach(function (expense) {
-                total += expense.Cost
-                expense.Cost = Number(expense.Cost).toFixed(2)
-                if (expense.ApprovedCost !== null) {
-                  expense.ApprovedCost = Number(expense.ApprovedCost).toFixed(2)
-                }
-                if (expense.ExpenseType === 'car' && expense.Status === null) {
-                  expense.Status = 'APPROVED-DIFF-AMOUNT'
-                }
-              })
-              claim.Total = Number(total).toFixed(2)
-              return claimExpenses
-            })
-            .then(function (claimExpenses) {
-              return knex('ClaimDeduction')
-                .where({'ClaimId': claimId, 'IsEnabled': true})
-                .then(function (claimDeductions) {
-                  var deductions = []
-                  var deductionTotal = 0
-                  claimDeductions.forEach(function (claimDeduction) {
-                    deductionTotal += claimDeduction.Amount
-                    deductions.push(claimDeduction)
-                  })
+}
 
-                  claim.Total = Number(claim.Total - deductionTotal).toFixed(2)
+function getClaimDocuments (claimId) {
+  return knex('ClaimDocument')
+    .where({'ClaimDocument.ClaimId': claimId, 'ClaimDocument.IsEnabled': true, 'ClaimDocument.ClaimExpenseId': null})
+    .select(
+      'ClaimDocument.ClaimDocumentId',
+      'ClaimDocument.DocumentStatus',
+      'ClaimDocument.Filepath',
+      'ClaimDocument.DocumentType')
+    .orderBy('ClaimDocument.DateSubmitted', 'desc')
+}
 
-                  return knex('Claim')
-                    .join('ClaimChild', 'Claim.ClaimId', '=', 'ClaimChild.ClaimId')
-                    .where({ 'Claim.ClaimId': claimId, 'ClaimChild.IsEnabled': true })
-                    .select()
-                    .orderBy('ClaimChild.Name')
-                    .then(function (claimChild) {
-                      claimDetails = {
-                        claim: claim,
-                        claimExpenses: claimExpenses,
-                        claimChild: claimChild,
-                        deductions: deductions
-                      }
-
-                      return duplicateClaimCheck(claimId, claimDetails.claim.NationalInsuranceNumber, claimDetails.claim.PrisonNumber, claimDetails.claim.DateOfJourney)
-                    })
-                })
-                .then(function (result) {
-                  claimDetails.duplicates = result
-
-                  return knex('ClaimEvent')
-                    .where('ClaimId', claimId)
-                    .then(function (claimEvents) {
-                      claimDetails.claimEvents = claimEvents
-
-                      return claimDetails
-                    })
-                })
-            })
-        })
+function getClaimExpenses (claimId) {
+  return knex('Claim')
+    .join('ClaimExpense', 'Claim.ClaimId', '=', 'ClaimExpense.ClaimId')
+    .where('Claim.ClaimId', claimId)
+    .select('ClaimExpense.*', 'ClaimDocument.DocumentStatus', 'ClaimDocument.DocumentType', 'ClaimDocument.ClaimDocumentId', 'ClaimDocument.Filepath')
+    .leftJoin('ClaimDocument', function () {
+      this
+        .on('ClaimExpense.ClaimId', 'ClaimDocument.ClaimId')
+        .on('ClaimExpense.ClaimExpenseId', 'ClaimDocument.ClaimExpenseId')
+        .on('ClaimExpense.IsEnabled', 'ClaimDocument.IsEnabled')
     })
+    .orderBy('ClaimExpense.ClaimExpenseId')
+}
+
+function getClaimDeductions (claimId) {
+  return knex('ClaimDeduction')
+    .where({'ClaimId': claimId, 'IsEnabled': true})
+}
+
+function getClaimChildren (claimId) {
+  return knex('Claim')
+    .join('ClaimChild', 'Claim.ClaimId', '=', 'ClaimChild.ClaimId')
+    .where({ 'Claim.ClaimId': claimId, 'ClaimChild.IsEnabled': true })
+    .select()
+    .orderBy('ClaimChild.Name')
+}
+
+function getClaimEvents (claimId) {
+  return knex('ClaimEvent')
+    .where('ClaimId', claimId)
+}
+
+function setClaimExpenseStatusForCarJourneys (claimExpenses) {
+  claimExpenses.forEach(function (claimExpense) {
+    if (claimExpense.ExpenseType === 'car' && claimExpense.Status === null) {
+      claimExpense.Status = 'APPROVED-DIFF-AMOUNT'
+    }
+  })
+
+  return claimExpenses
+}
+
+function appendClaimDocumentsToClaim (claim, claimDocuments) {
+  claim.benefitDocument = []
+  claimDocuments.forEach(function (document) {
+    if (document.DocumentType === 'VISIT-CONFIRMATION') {
+      claim.visitConfirmation = document
+    } else {
+      claim.benefitDocument.push(document)
+    }
+  })
+
+  return claim
 }

--- a/app/services/data/insert-deduction.js
+++ b/app/services/data/insert-deduction.js
@@ -5,6 +5,7 @@ module.exports = function (claimId, deductionType, amount) {
   return getClaim(claimId)
     .then(function (claim) {
       return knex('IntSchema.ClaimDeduction')
+        .returning('ClaimDeductionId')
         .insert({
           EligibilityId: claim.EligibilityId,
           Reference: claim.Reference,
@@ -13,7 +14,6 @@ module.exports = function (claimId, deductionType, amount) {
           DeductionType: deductionType,
           IsEnabled: true
         })
-        .returning('ClaimDeductionId')
     })
 }
 

--- a/app/services/data/insert-deduction.js
+++ b/app/services/data/insert-deduction.js
@@ -1,7 +1,7 @@
 const config = require('../../../knexfile').intweb
 const knex = require('knex')(config)
 
-module.exports = function (claimId, deductionType, amount) {
+module.exports = function (claimId, claimDeduction) {
   return getClaim(claimId)
     .then(function (claim) {
       return knex('IntSchema.ClaimDeduction')
@@ -10,8 +10,8 @@ module.exports = function (claimId, deductionType, amount) {
           EligibilityId: claim.EligibilityId,
           Reference: claim.Reference,
           ClaimId: claimId,
-          Amount: amount,
-          DeductionType: deductionType,
+          Amount: claimDeduction.amount,
+          DeductionType: claimDeduction.deductionType,
           IsEnabled: true
         })
     })

--- a/app/services/data/insert-deduction.js
+++ b/app/services/data/insert-deduction.js
@@ -1,0 +1,24 @@
+const config = require('../../../knexfile').intweb
+const knex = require('knex')(config)
+
+module.exports = function (claimId, deductionType, amount) {
+  return getClaim(claimId)
+    .then(function (claim) {
+      return knex('IntSchema.ClaimDeduction')
+        .insert({
+          EligibilityId: claim.EligibilityId,
+          Reference: claim.Reference,
+          ClaimId: claimId,
+          Amount: amount,
+          DeductionType: deductionType,
+          IsEnabled: true
+        })
+        .returning('ClaimDeductionId')
+    })
+}
+
+function getClaim (claimId) {
+  return knex('IntSchema.Claim')
+    .where('ClaimId', claimId)
+    .first()
+}

--- a/app/services/domain/claim-deduction.js
+++ b/app/services/domain/claim-deduction.js
@@ -1,0 +1,29 @@
+const ValidationError = require('../errors/validation-error')
+const FieldValidator = require('../validators/field-validator')
+const ErrorHandler = require('../validators/error-handler')
+
+class ClaimDeduction {
+  constructor (deductionType, amount) {
+    this.deductionType = deductionType
+    this.amount = amount
+    this.IsValid()
+  }
+
+  IsValid () {
+    var errors = ErrorHandler()
+
+    FieldValidator(this.deductionType, 'deduction-type', errors)
+      .isRequired()
+
+    FieldValidator(this.amount, 'deduction-amount', errors)
+      .isRequired()
+
+    var validationErrors = errors.get()
+
+    if (validationErrors) {
+      throw new ValidationError(validationErrors)
+    }
+  }
+}
+
+module.exports = ClaimDeduction

--- a/app/services/domain/claim-deduction.js
+++ b/app/services/domain/claim-deduction.js
@@ -17,6 +17,8 @@ class ClaimDeduction {
 
     FieldValidator(this.amount, 'deduction-amount', errors)
       .isRequired()
+      .isCurrency()
+      .isGreaterThanZero()
 
     var validationErrors = errors.get()
 

--- a/app/services/get-claim-total-amount.js
+++ b/app/services/get-claim-total-amount.js
@@ -1,0 +1,17 @@
+module.exports = function (claimExpenses, claimDeductions) {
+  var total = 0
+
+  if (claimExpenses && claimExpenses.length > 0) {
+    claimExpenses.forEach(function (claimExpense) {
+      total += claimExpense.Cost
+    })
+  }
+
+  if (claimDeductions && claimDeductions.length > 0) {
+    claimDeductions.forEach(function (claimDeduction) {
+      total -= claimDeduction.Amount
+    })
+  }
+
+  return Number(total).toFixed(2)
+}

--- a/app/services/validators/validation-field-names.js
+++ b/app/services/validators/validation-field-names.js
@@ -6,5 +6,7 @@ module.exports = {
   'nomis-check': 'NOMIS check',
   'dwp-check': 'Benefit check',
   'visit-confirmation-check': 'Visit confirmation check',
-  'upload': 'A document upload'
+  'upload': 'A document upload',
+  'deduction-type': 'A deduction type',
+  'deduction-amount': 'A deduction amount'
 }

--- a/app/views/claim/view-claim.html
+++ b/app/views/claim/view-claim.html
@@ -82,6 +82,10 @@
 
     <br>
 
+    {% include "partials/view-claim/add-deduction.html" %}
+
+    <br>
+
     {% include "partials/view-claim/claim-events.html" %}
 
     <br>

--- a/app/views/helpers/display-helper.js
+++ b/app/views/helpers/display-helper.js
@@ -1,6 +1,7 @@
 const prisonsEnum = require('../../constants/prisons-enum')
 const benefitsEnum = require('../../constants/benefits-enum')
 const claimTypeEnum = require('../../constants/claim-type-enum')
+const deductionTypeEnum = require('../../constants/deduction-type-enum')
 const enumHelper = require('../../constants/helpers/enum-helper')
 
 module.exports.getBenefitDisplayName = function (value) {
@@ -30,5 +31,10 @@ module.exports.getPrisonRegion = function (value) {
 
 module.exports.getClaimTypeDisplayName = function (value) {
   var element = enumHelper.getKeyByValue(claimTypeEnum, value)
+  return element.displayName
+}
+
+module.exports.getDeductionTypeDisplayName = function (value) {
+  var element = enumHelper.getKeyByValue(deductionTypeEnum, value)
   return element.displayName
 }

--- a/app/views/partials/view-claim/add-deduction.html
+++ b/app/views/partials/view-claim/add-deduction.html
@@ -1,0 +1,20 @@
+<h1 class="table-heading">Deduction</h1>
+<table>
+  <tbody>
+    <tr>
+      <td>
+        Type: <select id="deductionType" name="deductionType" class="form-control">
+          <option selected>Select</option>
+          <option value="hc3">{{ displayHelper.getDeductionTypeDisplayName('hc3') }}</option>
+          <option value="overpayment">{{ displayHelper.getDeductionTypeDisplayName('overpayment') }}</option>
+        </select>
+      </td>
+      <td>
+        Amount: <input id="deductionAmount" name="deductionAmount" type="text" class="form-control">
+      </td>
+      <td>
+        <input type="submit" class="button pull-right" name="add-deduction" id="add-deduction" value="Submit">
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/partials/view-claim/add-deduction.html
+++ b/app/views/partials/view-claim/add-deduction.html
@@ -13,7 +13,7 @@
         Amount: <input id="deductionAmount" name="deductionAmount" type="text" class="form-control">
       </td>
       <td>
-        <input type="submit" class="button pull-right" name="add-deduction" id="add-deduction" value="Submit">
+        <input type="submit" class="button pull-right grey" name="add-deduction" id="add-deduction" value="Submit">
       </td>
     </tr>
   </tbody>

--- a/app/views/partials/view-claim/claim.html
+++ b/app/views/partials/view-claim/claim.html
@@ -62,7 +62,7 @@
         <br>
         Deduction
       </td>
-      <td>£{{ deduction['Amount'] }}</td>
+      <td>-£{{ deduction['Amount'] }}</td>
       <td></td>
       <td><input type="submit" name='remove-deduction-{{ deduction.ClaimDeductionId }}' class='button pull-right grey' value='Remove'></td>
     </tr>

--- a/app/views/partials/view-claim/claim.html
+++ b/app/views/partials/view-claim/claim.html
@@ -64,7 +64,7 @@
       </td>
       <td>£{{ deduction['Amount'] }}</td>
       <td></td>
-      <td><input type="submit" name='remove-deduction-{{ deduction.ClaimDeductionId }}' class='button pull-right' value='Remove'></td>
+      <td><input type="submit" name='remove-deduction-{{ deduction.ClaimDeductionId }}' class='button pull-right grey' value='Remove'></td>
     </tr>
     {% endfor %}
 

--- a/app/views/partials/view-claim/claim.html
+++ b/app/views/partials/view-claim/claim.html
@@ -54,6 +54,19 @@
       </tr>
 
     {% endfor %}
+    
+    {% for deduction in deductions %}
+    <tr>
+      <td>
+        <span class="bold">{{ displayHelper.getDeductionTypeDisplayName(deduction.DeductionType) }}</span>
+        <br>
+        Deduction
+      </td>
+      <td>£{{ deduction['Amount'] }}</td>
+      <td></td>
+      <td><input type="submit" name='remove-deduction-{{ deduction.ClaimDeductionId }}' class='button pull-right' value='Remove'></td>
+    </tr>
+    {% endfor %}
 
     <tr class="no-border">
       <td class="text-right"><h3 class="heading-small space-right">Total Expense Cost:</h3></td>

--- a/migrations/20161206143926_add-claim-deduction.js
+++ b/migrations/20161206143926_add-claim-deduction.js
@@ -1,0 +1,26 @@
+exports.up = function (knex, Promise) {
+  return knex.schema.createTable('ClaimDeduction', function (table) {
+    table.increments('ClaimDeductionId')
+    table.integer('EligibilityId').unsigned().notNullable()
+    table.string('Reference', 10).notNullable().index()
+    table.integer('ClaimId').unsigned().notNullable().references('Claim.ClaimId')
+    table.string('DeductionType', 100).notNullable()
+    table.decimal('Amount').notNullable()
+    table.boolean('IsEnabled')
+  })
+  .then(function () {
+    return knex.schema.alterTable('ClaimDeduction', function (table) {
+      table
+        .foreign(['ClaimId', 'EligibilityId', 'Reference'])
+        .references(['Claim.ClaimId', 'Claim.EligibilityId', 'Claim.Reference'])
+    })
+  })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
+}
+
+exports.down = function (knex, Promise) {
+  return knex.schema.dropTable('ClaimDeduction')
+}

--- a/test/helpers/database-setup-for-tests.js
+++ b/test/helpers/database-setup-for-tests.js
@@ -259,6 +259,7 @@ module.exports.deleteAll = function (reference) {
     .then(function () { return deleteByReference('IntSchema.ClaimDocument', reference) })
     .then(function () { return deleteByReference('IntSchema.ClaimExpense', reference) })
     .then(function () { return deleteByReference('IntSchema.ClaimChild', reference) })
+    .then(function () { return deleteByReference('IntSchema.ClaimDeduction', reference) })
     .then(function () { return deleteByReference('IntSchema.Claim', reference) })
     .then(function () { return deleteByReference('IntSchema.Visitor', reference) })
     .then(function () { return deleteByReference('IntSchema.Prisoner', reference) })

--- a/test/helpers/database-setup-for-tests.js
+++ b/test/helpers/database-setup-for-tests.js
@@ -320,14 +320,14 @@ module.exports.getTestData = function (reference, status) {
     },
     ClaimExpenses: [{
       ExpenseType: 'train',
-      Cost: '12.50',
+      Cost: 12,
       From: 'London',
       To: 'Hewell',
       IsReturn: true
     },
     {
       ExpenseType: 'accommodation',
-      Cost: '80.00',
+      Cost: 80,
       DurationOfTravel: 1
     }],
     ClaimChild: [{

--- a/test/helpers/database-setup-for-tests.js
+++ b/test/helpers/database-setup-for-tests.js
@@ -244,6 +244,32 @@ module.exports.insertTestDataForIds = function (reference, date, status, visitDa
     })
     .then(function (result) {
       ids.claimEventId2 = result[0]
+      return knex('IntSchema.ClaimDeduction')
+        .returning('ClaimDeductionId')
+        .insert({
+          EligibilityId: ids.eligibilityId,
+          Reference: reference,
+          ClaimId: uniqueId,
+          Amount: data.ClaimDeduction['hc3'].Amount,
+          DeductionType: data.ClaimDeduction['hc3'].DeductionType,
+          IsEnabled: true
+        })
+    })
+    .then(function (result) {
+      ids.claimDeductionId1 = result[0]
+      return knex('IntSchema.ClaimDeduction')
+        .returning('ClaimDeductionId')
+        .insert({
+          EligibilityId: ids.eligibilityId,
+          Reference: reference,
+          ClaimId: uniqueId,
+          Amount: data.ClaimDeduction['overpayment'].Amount,
+          DeductionType: data.ClaimDeduction['overpayment'].DeductionType,
+          IsEnabled: true
+        })
+    })
+    .then(function (result) {
+      ids.claimDeductionId2 = result[0]
       return ids
     })
 }
@@ -345,6 +371,18 @@ module.exports.getTestData = function (reference, status) {
         Caseworker: 'Jane Bloggs',
         IsInternal: false
       }
-    ]
+    ],
+    ClaimDeduction: {
+      'overpayment': {
+        Amount: 5,
+        DeductionType: 'overpayment',
+        IsEnabled: true
+      },
+      'hc3': {
+        Amount: 10,
+        DeductionType: 'hc3',
+        IsEnabled: true
+      }
+    }
   }
 }

--- a/test/integration/services/data/test-disable-deduction.js
+++ b/test/integration/services/data/test-disable-deduction.js
@@ -1,0 +1,42 @@
+const expect = require('chai').expect
+const moment = require('moment')
+const config = require('../../../../knexfile').intweb
+const knex = require('knex')(config)
+const databaseHelper = require('../../../helpers/database-setup-for-tests')
+
+const disableDeduction = require('../../../../app/services/data/disable-deduction')
+var reference = 'V123456'
+var date
+var claimDeductionId
+
+describe('services/data/insert-deduction', function () {
+  describe('module', function () {
+    before(function () {
+      date = moment()
+      return databaseHelper.insertTestData(reference, date.toDate(), 'TESTING').then(function (ids) {
+        claimDeductionId = ids.claimDeductionId1
+      })
+    })
+
+    it('should set IsEnabled to false for the specified ClaimDeduction a claim deduction when called', function () {
+      var claimDeduction
+
+      return disableDeduction(claimDeductionId)
+        .then(function (claimDeductionId) {
+          return knex('ClaimDeduction').first().where('ClaimDeductionId', claimDeductionId)
+            .then(function (deduction) {
+              claimDeduction = deduction
+
+              expect(claimDeduction.IsEnabled).to.be.false
+            })
+        })
+        .catch(function (error) {
+          throw error
+        })
+    })
+
+    after(function () {
+      return databaseHelper.deleteAll(reference)
+    })
+  })
+})

--- a/test/integration/services/data/test-get-individual-claim-details.js
+++ b/test/integration/services/data/test-get-individual-claim-details.js
@@ -38,6 +38,8 @@ describe('services/data/get-individual-claim-details', function () {
           expect(result.claimChild[1].Name).to.equal(testData.ClaimChild[1].Name)
           expect(result.claimEvents[0].Caseworker).to.equal(testData.ClaimEvent[0].Caseworker)
           expect(result.claimEvents[1].Caseworker).to.equal(testData.ClaimEvent[1].Caseworker)
+          expect(result.deductions[0].DeductionType).to.equal(testData.ClaimDeduction['hc3'].DeductionType)
+          expect(result.deductions[1].DeductionType).to.equal(testData.ClaimDeduction['overpayment'].DeductionType)
         })
         .catch(function (error) {
           throw error

--- a/test/integration/services/data/test-insert-deduction.js
+++ b/test/integration/services/data/test-insert-deduction.js
@@ -1,0 +1,53 @@
+const expect = require('chai').expect
+const moment = require('moment')
+const config = require('../../../../knexfile').intweb
+const knex = require('knex')(config)
+const databaseHelper = require('../../../helpers/database-setup-for-tests')
+
+const insertDeduction = require('../../../../app/services/data/insert-deduction')
+const deductionTypeEnum = require('../../../../app/constants/deduction-type-enum')
+var reference = 'V123456'
+var date
+var claimId
+
+describe('services/data/insert-deduction', function () {
+  describe('module', function () {
+    before(function () {
+      date = moment()
+      return databaseHelper.insertTestData(reference, date.toDate(), 'TESTING').then(function (ids) {
+        claimId = ids.claimId
+      })
+    })
+
+    it('should add a claim deduction when called', function () {
+      var claimDeduction
+      var claimDeductionType = deductionTypeEnum.OVERPAYMENT.value
+      var claimDeductionAmount = 5
+
+      return insertDeduction(claimId, claimDeductionType, claimDeductionAmount)
+        .then(function (claimDeductionId) {
+          return knex('ClaimDeduction').first().where('ClaimDeductionId', claimDeductionId)
+            .then(function (deduction) {
+              claimDeduction = deduction
+
+              return knex('Claim').first().where('ClaimId', claimId)
+                .then(function (claim) {
+                  expect(claimDeduction.EligibilityId).to.equal(claim.EligibilityId)
+                  expect(claimDeduction.Reference).to.equal(claim.Reference)
+                  expect(claimDeduction.ClaimId).to.equal(claim.ClaimId)
+                  expect(claimDeduction.Amount).to.equal(claimDeductionAmount)
+                  expect(claimDeduction.DeductionType).to.equal(claimDeductionType)
+                  expect(claimDeduction.IsEnabled).to.be.true
+                })
+            })
+        })
+        .catch(function (error) {
+          throw error
+        })
+    })
+
+    after(function () {
+      return databaseHelper.deleteAll(reference)
+    })
+  })
+})

--- a/test/integration/services/data/test-insert-deduction.js
+++ b/test/integration/services/data/test-insert-deduction.js
@@ -6,6 +6,7 @@ const databaseHelper = require('../../../helpers/database-setup-for-tests')
 
 const insertDeduction = require('../../../../app/services/data/insert-deduction')
 const deductionTypeEnum = require('../../../../app/constants/deduction-type-enum')
+const ClaimDeduction = require('../../../../app/services/domain/claim-deduction')
 var reference = 'V123456'
 var date
 var claimId
@@ -20,24 +21,24 @@ describe('services/data/insert-deduction', function () {
     })
 
     it('should add a claim deduction when called', function () {
-      var claimDeduction
       var claimDeductionType = deductionTypeEnum.OVERPAYMENT.value
       var claimDeductionAmount = 5
+      var claimDeduction = new ClaimDeduction(claimDeductionType, claimDeductionAmount.toString())
 
-      return insertDeduction(claimId, claimDeductionType, claimDeductionAmount)
+      return insertDeduction(claimId, claimDeduction)
         .then(function (claimDeductionId) {
           return knex('ClaimDeduction').first().where('ClaimDeductionId', claimDeductionId)
             .then(function (deduction) {
-              claimDeduction = deduction
+              var updatedClaimDeduction = deduction
 
               return knex('Claim').first().where('ClaimId', claimId)
                 .then(function (claim) {
-                  expect(claimDeduction.EligibilityId).to.equal(claim.EligibilityId)
-                  expect(claimDeduction.Reference).to.equal(claim.Reference)
-                  expect(claimDeduction.ClaimId).to.equal(claim.ClaimId)
-                  expect(claimDeduction.Amount).to.equal(claimDeductionAmount)
-                  expect(claimDeduction.DeductionType).to.equal(claimDeductionType)
-                  expect(claimDeduction.IsEnabled).to.be.true
+                  expect(updatedClaimDeduction.EligibilityId).to.equal(claim.EligibilityId)
+                  expect(updatedClaimDeduction.Reference).to.equal(claim.Reference)
+                  expect(updatedClaimDeduction.ClaimId).to.equal(claim.ClaimId)
+                  expect(updatedClaimDeduction.Amount).to.equal(claimDeductionAmount)
+                  expect(updatedClaimDeduction.DeductionType).to.equal(claimDeductionType)
+                  expect(updatedClaimDeduction.IsEnabled).to.be.true
                 })
             })
         })

--- a/test/unit/services/domain/test-claim-deduction.js
+++ b/test/unit/services/domain/test-claim-deduction.js
@@ -4,9 +4,9 @@ const expect = require('chai').expect
 const deductionTypeEnum = require('../../../../app/constants/deduction-type-enum')
 var claimDeduction
 
-describe('services/domain/claim-decision', function () {
+describe('services/domain/claim-deduction', function () {
   const VALID_DEDUCTION_TYPE = deductionTypeEnum.HC3_DEDUCTION
-  const VALID_AMOUNT = 10
+  const VALID_AMOUNT = '10'
 
   it('should construct a domain object given valid input', function () {
     claimDeduction = new ClaimDeduction(VALID_DEDUCTION_TYPE, VALID_AMOUNT)
@@ -18,7 +18,6 @@ describe('services/domain/claim-decision', function () {
     try {
       claimDeduction = new ClaimDeduction('', VALID_AMOUNT)
     } catch (e) {
-      console.dir(e.validationErrors)
       expect(e).to.be.instanceof(ValidationError)
       expect(e.validationErrors['deduction-type'][0]).to.equal('A deduction type is required')
     }
@@ -26,9 +25,8 @@ describe('services/domain/claim-decision', function () {
 
   it('should return isRequired error for decision if amount is empty or zero', function () {
     try {
-      claimDeduction = new ClaimDeduction(VALID_DEDUCTION_TYPE, 0)
+      claimDeduction = new ClaimDeduction(VALID_DEDUCTION_TYPE, '')
     } catch (e) {
-      console.dir(e.validationErrors)
       expect(e).to.be.instanceof(ValidationError)
       expect(e.validationErrors['deduction-amount'][0]).to.equal('A deduction amount is required')
     }

--- a/test/unit/services/domain/test-claim-deduction.js
+++ b/test/unit/services/domain/test-claim-deduction.js
@@ -1,0 +1,36 @@
+const ClaimDeduction = require('../../../../app/services/domain/claim-deduction')
+const ValidationError = require('../../../../app/services/errors/validation-error')
+const expect = require('chai').expect
+const deductionTypeEnum = require('../../../../app/constants/deduction-type-enum')
+var claimDeduction
+
+describe('services/domain/claim-decision', function () {
+  const VALID_DEDUCTION_TYPE = deductionTypeEnum.HC3_DEDUCTION
+  const VALID_AMOUNT = 10
+
+  it('should construct a domain object given valid input', function () {
+    claimDeduction = new ClaimDeduction(VALID_DEDUCTION_TYPE, VALID_AMOUNT)
+    expect(claimDeduction.deductionType).to.equal(VALID_DEDUCTION_TYPE)
+    expect(claimDeduction.amount).to.equal(VALID_AMOUNT)
+  })
+
+  it('should return isRequired error for decision if deductionType is empty', function () {
+    try {
+      claimDeduction = new ClaimDeduction('', VALID_AMOUNT)
+    } catch (e) {
+      console.dir(e.validationErrors)
+      expect(e).to.be.instanceof(ValidationError)
+      expect(e.validationErrors['deduction-type'][0]).to.equal('A deduction type is required')
+    }
+  })
+
+  it('should return isRequired error for decision if amount is empty or zero', function () {
+    try {
+      claimDeduction = new ClaimDeduction(VALID_DEDUCTION_TYPE, 0)
+    } catch (e) {
+      console.dir(e.validationErrors)
+      expect(e).to.be.instanceof(ValidationError)
+      expect(e.validationErrors['deduction-amount'][0]).to.equal('A deduction amount is required')
+    }
+  })
+})

--- a/test/unit/services/test-get-claim-total-amount.js
+++ b/test/unit/services/test-get-claim-total-amount.js
@@ -1,0 +1,37 @@
+const expect = require('chai').expect
+const getClaimTotalAmount = require('../../../app/services/get-claim-total-amount')
+
+const claimExpenses = [
+  {
+    Cost: 5
+  },
+  {
+    Cost: 10
+  },
+  {
+    Cost: 15
+  }
+]
+
+const claimDeductions = [
+  {
+    Amount: 5
+  },
+  {
+    Amount: 5
+  }
+]
+
+describe('services/get-claim-total-amount', function () {
+  it('should calculate the total value from claim expenses and deductions', function () {
+    var total = getClaimTotalAmount(claimExpenses, claimDeductions)
+
+    expect(total).to.equal('20.00')
+  })
+
+  it('should calculate the correct total value from claim expenses only', function () {
+    var total = getClaimTotalAmount(claimExpenses, [])
+
+    expect(total).to.equal('30.00')
+  })
+})

--- a/test/unit/views/helpers/test-display-helper.js
+++ b/test/unit/views/helpers/test-display-helper.js
@@ -4,11 +4,13 @@ const displayHelper = require('../../../../app/views/helpers/display-helper')
 const prisonsEnum = require('../../../../app/constants/prisons-enum')
 const benefitsEnum = require('../../../../app/constants/benefits-enum')
 const claimTypeEnum = require('../../../../app/constants/claim-type-enum')
+const deductionTypeEnum = require('../../../../app/constants/deduction-type-enum')
 
 describe('views/helpers/display-helper', function () {
   const VALID_BENEFIT_VALUE = benefitsEnum.INCOME_SUPPORT.value
   const VALID_PRISON_VALUE = prisonsEnum.ALTCOURSE.value
   const VALID_CLAIM_TYPE_VALUE = claimTypeEnum.FIRST_TIME.value
+  const VALID_DEDUCTION_TYPE_VALUE = deductionTypeEnum.HC3_DEDUCTION.value
 
   it('should return the correct benefit display name given a valid value', function () {
     var result = displayHelper.getBenefitDisplayName(VALID_BENEFIT_VALUE)
@@ -38,5 +40,10 @@ describe('views/helpers/display-helper', function () {
   it('should return the correct claim type display name given a valid value', function () {
     var result = displayHelper.getClaimTypeDisplayName(VALID_CLAIM_TYPE_VALUE)
     expect(result).to.equal(claimTypeEnum.FIRST_TIME.displayName)
+  })
+
+  it('should return the correct deduction type display name given a valid value', function () {
+    var result = displayHelper.getDeductionTypeDisplayName(VALID_DEDUCTION_TYPE_VALUE)
+    expect(result).to.equal(deductionTypeEnum.HC3_DEDUCTION.displayName)
   })
 })


### PR DESCRIPTION
Added ability for caseworkers to add or disable deductions for a claim.

- Added migration for creating ClaimDeduction table in internal schema
- Added deduction-type-enum
- Updated view-claim post route so that users can add and disable claim deductions.
- Modified get-individual-claim-details so it should return any associated claim deductions
- Added ClaimDeduction domain object, includes validation
- Updated view-claim template to include partial template for deduction section
- Updated display-helper, now retrieves display names for deduction-type-enum
- Updated database-setup-for-tests, will now create test ClaimDeduction records

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards
- [x] Error Handling
