### PR TITLE
Filepath is no longer used in download links.

### DIFF
--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -1,5 +1,6 @@
 const authorisation = require('../../services/authorisation')
 const getIndividualClaimDetails = require('../../services/data/get-individual-claim-details')
+const getClaimDocumatFilePath = require('../../services/data/get-claim-document-file-path')
 const getDateFormatted = require('../../views/helpers/date-helper')
 const getClaimExpenseDetailFormatted = require('../../views/helpers/claim-expense-helper')
 const getChildFormatted = require('../../views/helpers/child-helper')
@@ -87,12 +88,19 @@ module.exports = function (router) {
   router.get('/claim/:claimId/download', function (req, res) {
     authorisation.isCaseworker(req)
 
-    var path = req.query.path
-    if (path) {
-      res.download(path)
-    } else {
-      throw new Error('No path to file provided')
+    var claimDocumentId = req.query['claim-document-id']
+    if (!claimDocumentId) {
+      throw new Error('Invalid Document ID')
     }
+
+    getClaimDocumatFilePath(claimDocumentId)
+      .then(function (document) {
+        if (document && document.Filepath) {
+          res.download(document.Filepath)
+        } else {
+          throw new Error('No path to file provided')
+        }
+      })
   })
 }
 

--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -1,6 +1,6 @@
 const authorisation = require('../../services/authorisation')
 const getIndividualClaimDetails = require('../../services/data/get-individual-claim-details')
-const getClaimDocumatFilePath = require('../../services/data/get-claim-document-file-path')
+const getClaimDocumentFilePath = require('../../services/data/get-claim-document-file-path')
 const getDateFormatted = require('../../views/helpers/date-helper')
 const getClaimExpenseDetailFormatted = require('../../views/helpers/claim-expense-helper')
 const getChildFormatted = require('../../views/helpers/child-helper')
@@ -93,7 +93,7 @@ module.exports = function (router) {
       throw new Error('Invalid Document ID')
     }
 
-    getClaimDocumatFilePath(claimDocumentId)
+    getClaimDocumentFilePath(claimDocumentId)
       .then(function (document) {
         if (document && document.Filepath) {
           res.download(document.Filepath)

--- a/app/services/data/get-claim-document-file-path.js
+++ b/app/services/data/get-claim-document-file-path.js
@@ -1,0 +1,11 @@
+const config = require('../../../knexfile').intweb
+const knex = require('knex')(config)
+
+module.exports = function (claimDocumentId) {
+  return knex('ClaimDocument')
+    .where({
+      'ClaimDocument.ClaimDocumentId': claimDocumentId,
+      'ClaimDocument.IsEnabled': true
+    })
+    .first('ClaimDocument.Filepath')
+}

--- a/app/views/partials/view-claim/claim.html
+++ b/app/views/partials/view-claim/claim.html
@@ -22,7 +22,7 @@
         <td>
           {% if receiptRequiredEnum[expense.ExpenseType] %}
             {% if expense.DocumentStatus == 'uploaded' %}
-              <a href="/claim/{{ Claim['ClaimId'] }}/download?path={{ expense['Filepath'] }}">View receipt</a>
+              <a href="/claim/{{ Claim['ClaimId'] }}/download?claim-document-id={{ expense['ClaimDocumentId'] }}">View receipt</a>
 
             {% elif expense.DocumentStatus == 'upload-later' %}
               <span class="text-pending">To be uploaded later</span>

--- a/app/views/partials/view-claim/visit.html
+++ b/app/views/partials/view-claim/visit.html
@@ -5,7 +5,7 @@
       <td>{{ getDateFormatted.shortDate(Claim['DateOfJourney']) }}</td>
       <td>
         {% if Claim.visitConfirmation['DocumentStatus'] == 'uploaded' %}
-          <a href="/claim/{{ Claim['ClaimId'] }}/download?path={{ Claim.visitConfirmation['Filepath'] }}">View confirmation</a>
+          <a href="/claim/{{ Claim['ClaimId'] }}/download?claim-document-id={{ Claim.visitConfirmation['ClaimDocumentId'] }}">View confirmation</a>
 
         {% elif Claim.visitConfirmation['DocumentStatus'] == 'upload-later' %}
           <span class="text-pending">To be uploaded later</span>

--- a/app/views/partials/view-claim/visitor.html
+++ b/app/views/partials/view-claim/visitor.html
@@ -56,7 +56,7 @@
       {% for document in Claim.benefitDocument %}
         <br>
         {% if document['DocumentStatus'] == 'uploaded' %}
-          <a href="/claim/{{ Claim['ClaimId'] }}/download?path={{ document['Filepath'] }}">View evidence</a>
+          <a href="/claim/{{ Claim['ClaimId'] }}/download?claim-document-id={{ document['ClaimDocumentId'] }}">View evidence</a>
         {% elif document['DocumentStatus'] == 'upload-later' %}
           <span class="text-pending">To be uploaded later</span>
           <a href="/claim/file-upload/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/{{ Claim['Benefit'] }}?eligibilityId={{ Claim['EligibilityId'] }}&claimDocumentId={{ document['ClaimDocumentId'] }}" id="add-benefit-documentation-upload-later" class="button grey pull-right">Add</a>

--- a/test/helpers/database-setup-for-tests.js
+++ b/test/helpers/database-setup-for-tests.js
@@ -160,6 +160,7 @@ module.exports.insertTestDataForIds = function (reference, date, status, visitDa
           Reference: reference,
           DocumentType: data.ClaimDocument['visit-confirmation'].DocumentType,
           DocumentStatus: data.ClaimDocument['visit-confirmation'].DocumentStatus,
+          Filepath: '/example/path/1',
           DateSubmitted: date,
           IsEnabled: data.ClaimDocument['visit-confirmation'].IsEnabled
         })
@@ -175,6 +176,7 @@ module.exports.insertTestDataForIds = function (reference, date, status, visitDa
           Reference: reference,
           DocumentType: data.ClaimDocument['benefit'].DocumentType,
           DocumentStatus: data.ClaimDocument['benefit'].DocumentStatus,
+          Filepath: '/example/path/2',
           DateSubmitted: date,
           IsEnabled: data.ClaimDocument['benefit'].IsEnabled
         })
@@ -191,6 +193,7 @@ module.exports.insertTestDataForIds = function (reference, date, status, visitDa
           Reference: reference,
           DocumentType: data.ClaimDocument['expense'].DocumentType,
           DocumentStatus: data.ClaimDocument['expense'].DocumentStatus,
+          Filepath: '/example/path/3',
           DateSubmitted: date,
           IsEnabled: data.ClaimDocument['expense'].IsEnabled
         })
@@ -207,6 +210,7 @@ module.exports.insertTestDataForIds = function (reference, date, status, visitDa
           Reference: reference,
           DocumentType: data.ClaimDocument['expense'].DocumentType,
           DocumentStatus: data.ClaimDocument['expense'].DocumentStatus,
+          Filepath: '/example/path/4',
           DateSubmitted: date,
           IsEnabled: data.ClaimDocument['expense'].IsEnabled
         })

--- a/test/integration/services/data/test-get-claim-document-file-path.js
+++ b/test/integration/services/data/test-get-claim-document-file-path.js
@@ -1,0 +1,32 @@
+var expect = require('chai').expect
+var moment = require('moment')
+var databaseHelper = require('../../../helpers/database-setup-for-tests')
+
+var getClaimDocumentFilePath = require('../../../../app/services/data/get-claim-document-file-path')
+var reference = 'V954638'
+var date
+var claimDocumentId
+
+describe('services/data/get-claim-document-file-path', function () {
+  before(function () {
+    date = moment()
+    return databaseHelper.insertTestData(reference, date.toDate(), 'TESTING')
+      .then(function (ids) {
+        claimDocumentId = ids.claimDocumentId1
+      })
+  })
+
+  it('should return list of claims and total', function () {
+    return getClaimDocumentFilePath(claimDocumentId)
+      .then(function (result) {
+        expect(result.Filepath).to.equal('/example/path/1')
+      })
+      .catch(function (error) {
+        throw error
+      })
+  })
+
+  after(function () {
+    return databaseHelper.deleteAll(reference)
+  })
+})

--- a/test/integration/services/data/test-get-claim-document-file-path.js
+++ b/test/integration/services/data/test-get-claim-document-file-path.js
@@ -16,7 +16,7 @@ describe('services/data/get-claim-document-file-path', function () {
       })
   })
 
-  it('should return list of claims and total', function () {
+  it('should have expected file path', function () {
     return getClaimDocumentFilePath(claimDocumentId)
       .then(function (result) {
         expect(result.Filepath).to.equal('/example/path/1')

--- a/test/unit/routes/claim/test-view-claim.js
+++ b/test/unit/routes/claim/test-view-claim.js
@@ -16,6 +16,7 @@ var stubCheckLastUpdated
 var stubInsertDeduction
 var stubDisableDeduction
 var stubClaimDeduction
+var stubGetClaimDocumatFilePath
 var ValidationError = require('../../../../app/services/errors/validation-error')
 var deductionTypeEnum = require('../../../../app/constants/deduction-type-enum')
 var bodyParser = require('body-parser')
@@ -52,6 +53,7 @@ describe('routes/claim/view-claim', function () {
     stubInsertDeduction = sinon.stub()
     stubDisableDeduction = sinon.stub()
     stubClaimDeduction = sinon.stub()
+    stubGetClaimDocumatFilePath = sinon.stub()
 
     var route = proxyquire('../../../../app/routes/claim/view-claim', {
       '../../services/authorisation': authorisation,
@@ -63,7 +65,8 @@ describe('routes/claim/view-claim', function () {
       '../../services/check-last-updated': stubCheckLastUpdated,
       '../../services/data/insert-deduction': stubInsertDeduction,
       '../../services/data/disable-deduction': stubDisableDeduction,
-      '../../services/domain/claim-deduction': stubClaimDeduction
+      '../../services/domain/claim-deduction': stubClaimDeduction,
+      '../../services/data/get-claim-document-file-path': stubGetClaimDocumatFilePath
     })
     app = express()
     app.use(bodyParser.json())
@@ -190,13 +193,16 @@ describe('routes/claim/view-claim', function () {
   })
 
   describe('GET /claim/:claimId/download', function () {
+    const CLAIM_DOCUMENT = {
+      Filepath: 'test/resources/testfile.txt'
+    }
+
     it('should respond respond with 200 if valid path entered', function () {
+      stubGetClaimDocumatFilePath.resolves(CLAIM_DOCUMENT)
       return supertest(app)
-        .get('/claim/123/download?path=test/resources/testfile.txt')
+        .get('/claim/123/download?claim-document-id=55')
         .expect(200)
-        .expect(function (response) {
-          expect(response.header['content-length']).to.equal('4')
-        })
+        .expect('content-length', '4')
     })
 
     it('should respond with 500 if no path provided', function () {

--- a/test/unit/routes/claim/test-view-claim.js
+++ b/test/unit/routes/claim/test-view-claim.js
@@ -16,7 +16,7 @@ var stubCheckLastUpdated
 var stubInsertDeduction
 var stubDisableDeduction
 var stubClaimDeduction
-var stubGetClaimDocumatFilePath
+var stubGetClaimDocumentFilePath
 var ValidationError = require('../../../../app/services/errors/validation-error')
 var deductionTypeEnum = require('../../../../app/constants/deduction-type-enum')
 var bodyParser = require('body-parser')
@@ -53,7 +53,7 @@ describe('routes/claim/view-claim', function () {
     stubInsertDeduction = sinon.stub()
     stubDisableDeduction = sinon.stub()
     stubClaimDeduction = sinon.stub()
-    stubGetClaimDocumatFilePath = sinon.stub()
+    stubGetClaimDocumentFilePath = sinon.stub()
 
     var route = proxyquire('../../../../app/routes/claim/view-claim', {
       '../../services/authorisation': authorisation,
@@ -66,7 +66,7 @@ describe('routes/claim/view-claim', function () {
       '../../services/data/insert-deduction': stubInsertDeduction,
       '../../services/data/disable-deduction': stubDisableDeduction,
       '../../services/domain/claim-deduction': stubClaimDeduction,
-      '../../services/data/get-claim-document-file-path': stubGetClaimDocumatFilePath
+      '../../services/data/get-claim-document-file-path': stubGetClaimDocumentFilePath
     })
     app = express()
     app.use(bodyParser.json())
@@ -197,15 +197,15 @@ describe('routes/claim/view-claim', function () {
       Filepath: 'test/resources/testfile.txt'
     }
 
-    it('should respond respond with 200 if valid path entered', function () {
-      stubGetClaimDocumatFilePath.resolves(CLAIM_DOCUMENT)
+    it('should respond respond with 200 if a valid file path is returned', function () {
+      stubGetClaimDocumentFilePath.resolves(CLAIM_DOCUMENT)
       return supertest(app)
         .get('/claim/123/download?claim-document-id=55')
         .expect(200)
         .expect('content-length', '4')
     })
 
-    it('should respond with 500 if no path provided', function () {
+    it('should respond with 500 if no claim-document-id provided', function () {
       return supertest(app)
         .get('/claim/123/download')
         .expect(500)


### PR DESCRIPTION
File path is no longer used in download links.
- Now ClaimDocumentID is passed to the download function instead of the file path.
- Updated all HTML files using the download logic to pass id rather than file path.
- Added a database query to retrieve a document file path by document id.
- Updated the test data creation for claim documents to include file paths.
- Added an integration test for the new database query.
- Updated unit tests.

Should close Taiga Task 926 & Taiga Story 885.

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards
- [x] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated