### PR TITLE
Feature/apvs 373/adding links for previous claim documents

### DIFF
--- a/app/services/data/get-claim-document-file-path.js
+++ b/app/services/data/get-claim-document-file-path.js
@@ -4,8 +4,7 @@ const knex = require('knex')(config)
 module.exports = function (claimDocumentId) {
   return knex('ClaimDocument')
     .where({
-      'ClaimDocument.ClaimDocumentId': claimDocumentId,
-      'ClaimDocument.IsEnabled': true
+      'ClaimDocument.ClaimDocumentId': claimDocumentId
     })
     .first('ClaimDocument.Filepath')
 }

--- a/app/views/partials/view-claim/claim-events.html
+++ b/app/views/partials/view-claim/claim-events.html
@@ -16,9 +16,13 @@
     <p>{{ claimEvent.AdditionalData }}</p>
 
     {% if claimEvent.IsInternal %}
-    <p>{{ claimEvent.Note|safe }}</p>
+      <p>{{ claimEvent.Note|safe }}</p>
+      {% if claimEvent['ClaimDocumentId'] %}
+        <br>
+        <a href="/claim/{{ Claim['ClaimId'] }}/download?claim-document-id={{ claimEvent['ClaimDocumentId'] }}">View previous document</a>
+      {% endif %}
     {% else %}
-    <p>{{ claimEvent.Note }}</p>
+      <p>{{ claimEvent.Note }}</p>
     {% endif %}
 
     <p class="time">{{ getDateFormatted.shortDateAndTime(claimEvent.DateAdded) }}</p>

--- a/app/views/partials/view-claim/decision.html
+++ b/app/views/partials/view-claim/decision.html
@@ -19,7 +19,7 @@
 
       <div class="form-group">
         <label class="form-label-bold" for="additional-info-accept">Additional information (optional)</label>
-        <textarea type="text" class="form-control full" name="additionalInfoApprove">{{ claimDecision['additionalInfoApprove'] }}</textarea>
+        <textarea type="text" class="form-control" name="additionalInfoApprove">{{ claimDecision['additionalInfoApprove'] }}</textarea>
       </div>
 
       <input type="submit" class="button" name="approve" id="approve-submit" value="Send confirmation email to claimant">
@@ -32,7 +32,7 @@
         {% if errors['note'][0] %}
           <span class="error-message" id="error-message-note-request">{{ errors['note'][0] }}</span>
         {% endif %}
-        <textarea type="text" class="form-control full" name="additionalInfoRequest">{{ claimDecision['additionalInfoRequest'] }}</textarea>
+        <textarea type="text" class="form-control" name="additionalInfoRequest">{{ claimDecision['additionalInfoRequest'] }}</textarea>
       </div>
 
       <input type="submit" class="button" name="request" value="Send request email to claimant">
@@ -45,7 +45,7 @@
         {% if errors['note'][0] %}
           <span class="error-message" id="error-message-note-reject">{{ errors['note'][0] }}</span>
         {% endif %}
-        <textarea type="text" class="form-control full" name="additionalInfoReject">{{ claimDecision['additionalInfoReject'] }}</textarea>
+        <textarea type="text" class="form-control" name="additionalInfoReject">{{ claimDecision['additionalInfoReject'] }}</textarea>
       </div>
 
       <input type="submit" class="button" name="reject" value="Send rejection email to claimant">


### PR DESCRIPTION
Made claim events capable of having download links for previous documents

* Added to view for claim events download links
* Made download not look for isEnable to allow downloading previous documents
* Altered message table size

## Checklist

- [ ] Unit tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
