### PR TITLE
Chore/fix rollback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,10 @@ run-end-to-end-tests-ie8.sh
 run-end-to-end-tests-firefox.sh
 run-integration-tests.sh
 run-knex-migrations.sh
+run-knex-rollback.sh
+run-nodemon.sh
 run-standard-linter.sh
+run-test-coverage.sh
 run-unit-tests.sh
 
 # Public directory

--- a/migrations/20161112173153_add-eligibility.js
+++ b/migrations/20161112173153_add-eligibility.js
@@ -19,4 +19,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.dropTable('Eligibility')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
 }

--- a/migrations/20161112173201_add-prisoner.js
+++ b/migrations/20161112173201_add-prisoner.js
@@ -25,4 +25,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.dropTable('Prisoner')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
 }

--- a/migrations/20161112173205_add-visitor.js
+++ b/migrations/20161112173205_add-visitor.js
@@ -35,4 +35,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.dropTable('Visitor')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
 }

--- a/migrations/20161112173210_add-claim.js
+++ b/migrations/20161112173210_add-claim.js
@@ -23,4 +23,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.dropTable('Claim')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
 }

--- a/migrations/20161112173218_add-claim-expense.js
+++ b/migrations/20161112173218_add-claim-expense.js
@@ -33,4 +33,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.dropTable('ClaimExpense')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
 }

--- a/migrations/20161112173244_add-claim-bank-details.js
+++ b/migrations/20161112173244_add-claim-bank-details.js
@@ -22,4 +22,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.dropTable('ClaimBankDetail')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
 }

--- a/migrations/20161112173306_add-task.js
+++ b/migrations/20161112173306_add-task.js
@@ -18,4 +18,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.dropTable('Task')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
 }

--- a/migrations/20161112173318_add-claim-document.js
+++ b/migrations/20161112173318_add-claim-document.js
@@ -27,4 +27,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.dropTable('ClaimDocument')
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }

--- a/migrations/20161112173325_add-claim-child.js
+++ b/migrations/20161112173325_add-claim-child.js
@@ -24,4 +24,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.dropTable('ClaimChild')
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }

--- a/migrations/20161114121441_update-claim-with-visit-confirmation-check.js
+++ b/migrations/20161114121441_update-claim-with-visit-confirmation-check.js
@@ -2,10 +2,18 @@ exports.up = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.string('VisitConfirmationCheck', 20)
   })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }
 
 exports.down = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.dropColumn('VisitConfirmationCheck')
+  })
+  .catch(function (error) {
+    console.log(error)
+    throw error
   })
 }

--- a/migrations/20161115143504_add-claim-column-caseworker.js
+++ b/migrations/20161115143504_add-claim-column-caseworker.js
@@ -3,11 +3,19 @@ exports.up = function (knex, Promise) {
     table.string('AssistedDigitalCaseworker', 100)
     table.string('Caseworker', 100)
   })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }
 
 exports.down = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.dropColumn('AssistedDigitalCaseworker')
     table.dropColumn('Caseworker')
+  })
+  .catch(function (error) {
+    console.log(error)
+    throw error
   })
 }

--- a/migrations/20161121132623_add-claim-document-column-caseworker.js
+++ b/migrations/20161121132623_add-claim-document-column-caseworker.js
@@ -2,10 +2,18 @@ exports.up = function (knex, Promise) {
   return knex.schema.table('ClaimDocument', function (table) {
     table.string('Caseworker', 100)
   })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }
 
 exports.down = function (knex, Promise) {
   return knex.schema.table('ClaimDocument', function (table) {
     table.dropColumn('Caseworker')
+  })
+  .catch(function (error) {
+    console.log(error)
+    throw error
   })
 }

--- a/migrations/20161123131340_add-claim-event.js
+++ b/migrations/20161123131340_add-claim-event.js
@@ -27,4 +27,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.dropTable('ClaimEvent')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
 }

--- a/migrations/20161123212652_add-claim-column-payment-status.js
+++ b/migrations/20161123212652_add-claim-column-payment-status.js
@@ -2,10 +2,18 @@ exports.up = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.string('PaymentStatus', 20)
   })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }
 
 exports.down = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.dropColumn('PaymentStatus')
+  })
+  .catch(function (error) {
+    console.log(error)
+    throw error
   })
 }

--- a/migrations/20161123212813_add-direct-payment-file.js
+++ b/migrations/20161123212813_add-direct-payment-file.js
@@ -14,4 +14,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.dropTable('DirectPaymentFile')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
 }

--- a/migrations/20161125155944_add-timestamp-last-updated-to-claim-table.js
+++ b/migrations/20161125155944_add-timestamp-last-updated-to-claim-table.js
@@ -13,19 +13,25 @@ exports.down = function (knex, Promise) {
     // Retrieve the name of the constraint on the LastUpdated column and remove it before dropping the column.
     .raw(
       `
-        DECLARE @Constraint varchar(100);
-        SET @Constraint = (
-          SELECT o.name 
-          FROM sysobjects o 
-          INNER JOIN syscolumns c 
-            ON o.id = c.cdefault 
-          INNER JOIN sysobjects t 
-            ON c.id = t.id 
-          WHERE o.xtype = 'D' 
-          AND c.name = 'LastUpdated' 
-        )
+        DECLARE @table_id AS INT
+        DECLARE @name_column_id AS INT
+        DECLARE @sql nvarchar(255) 
         
-
+        -- Find table id
+        SET @table_id = OBJECT_ID('IntSchema.Claim')
+        
+        -- Find name column id
+        SELECT @name_column_id = column_id
+        FROM sys.columns
+        WHERE object_id = @table_id
+        AND name = 'LastUpdated'
+        
+        -- Remove default constraint from column
+        SELECT @sql = 'ALTER TABLE IntSchema.Claim DROP CONSTRAINT ' + D.name
+        FROM sys.default_constraints AS D
+        WHERE D.parent_object_id = @table_id
+        AND D.parent_column_id = @name_column_id
+        EXECUTE sp_executesql @sql
       `
     )
     .table('Claim', function (table) {

--- a/migrations/20161125155944_add-timestamp-last-updated-to-claim-table.js
+++ b/migrations/20161125155944_add-timestamp-last-updated-to-claim-table.js
@@ -2,10 +2,37 @@ exports.up = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.timestamp('LastUpdated').defaultTo(knex.fn.now())
   })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }
 
 exports.down = function (knex, Promise) {
-  return knex.schema.table('Claim', function (table) {
-    table.dropColumn('LastUpdated')
-  })
+  return knex.schema
+    // Retrieve the name of the constraint on the LastUpdated column and remove it before dropping the column.
+    .raw(
+      `
+        DECLARE @Constraint varchar(100);
+        SET @Constraint = (
+          SELECT o.name 
+          FROM sysobjects o 
+          INNER JOIN syscolumns c 
+            ON o.id = c.cdefault 
+          INNER JOIN sysobjects t 
+            ON c.id = t.id 
+          WHERE o.xtype = 'D' 
+          AND c.name = 'LastUpdated' 
+        )
+        
+
+      `
+    )
+    .table('Claim', function (table) {
+      table.dropColumn('LastUpdated')
+    })
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
 }

--- a/migrations/20161128121352_add-claim-type-to-claim.js
+++ b/migrations/20161128121352_add-claim-type-to-claim.js
@@ -2,10 +2,18 @@ exports.up = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.string('ClaimType', 50)
   })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }
 
 exports.down = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.dropColumn('ClaimType')
+  })
+  .catch(function (error) {
+    console.log(error)
+    throw error
   })
 }

--- a/migrations/20161130141358_add-claim-payment-amount-column.js
+++ b/migrations/20161130141358_add-claim-payment-amount-column.js
@@ -2,10 +2,18 @@ exports.up = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.decimal('PaymentAmount')
   })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }
 
 exports.down = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.dropColumn('PaymentAmount')
+  })
+  .catch(function (error) {
+    console.log(error)
+    throw error
   })
 }

--- a/migrations/20161201133531_add_date_reviewed_column.js
+++ b/migrations/20161201133531_add_date_reviewed_column.js
@@ -2,10 +2,18 @@ exports.up = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.dateTime('DateReviewed')
   })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }
 
 exports.down = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.dropColumn('DateReviewed')
+  })
+  .catch(function (error) {
+    console.log(error)
+    throw error
   })
 }

--- a/migrations/20161205170059_add-claim-column-is-advance-claim.js
+++ b/migrations/20161205170059_add-claim-column-is-advance-claim.js
@@ -2,10 +2,18 @@ exports.up = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.boolean('IsAdvanceClaim')
   })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }
 
 exports.down = function (knex, Promise) {
   return knex.schema.table('Claim', function (table) {
     table.dropColumn('IsAdvanceClaim')
+  })
+  .catch(function (error) {
+    console.log(error)
+    throw error
   })
 }

--- a/migrations/20161206143926_add-claim-deduction.js
+++ b/migrations/20161206143926_add-claim-deduction.js
@@ -23,4 +23,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.dropTable('ClaimDeduction')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
 }

--- a/migrations/20161208105900_add_auto_approval_config.js
+++ b/migrations/20161208105900_add_auto_approval_config.js
@@ -39,4 +39,8 @@ exports.down = function (knex, Promise) {
     .then(function () {
       return knex.schema.dropTable('AutoApprovalConfig')
     })
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
 }

--- a/migrations/20161208151237_add-overpayment-columns.js
+++ b/migrations/20161208151237_add-overpayment-columns.js
@@ -5,6 +5,10 @@ exports.up = function (knex, Promise) {
     table.decimal('RemainingOverpaymentAmount')
     table.string('OverpaymentReason', 250)
   })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }
 
 exports.down = function (knex, Promise) {
@@ -13,5 +17,9 @@ exports.down = function (knex, Promise) {
     table.dropColumn('OverpaymentAmount')
     table.dropColumn('RemainingOverpaymentAmount')
     table.dropColumn('OverpaymentReason')
+  })
+  .catch(function (error) {
+    console.log(error)
+    throw error
   })
 }

--- a/migrations/20161213113840_add-claim-document-id-column-to-claim-event.js
+++ b/migrations/20161213113840_add-claim-document-id-column-to-claim-event.js
@@ -2,11 +2,20 @@ exports.up = function (knex, Promise) {
   return knex.schema.table('ClaimEvent', function (table) {
     table.integer('ClaimDocumentId').unsigned().references('ClaimDocument.ClaimDocumentId')
   })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
 }
 
 exports.down = function (knex, Promise) {
   return knex.schema.table('ClaimEvent', function (table) {
+    table.dropForeign('ClaimDocumentId');
     table.dropColumn('ClaimDocumentId')
+  })
+  .catch(function (error) {
+    console.log(error)
+    throw error
   })
 }
 

--- a/migrations/20161213113840_add-claim-document-id-column-to-claim-event.js
+++ b/migrations/20161213113840_add-claim-document-id-column-to-claim-event.js
@@ -10,7 +10,7 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex.schema.table('ClaimEvent', function (table) {
-    table.dropForeign('ClaimDocumentId');
+    table.dropForeign('ClaimDocumentId')
     table.dropColumn('ClaimDocumentId')
   })
   .catch(function (error) {


### PR DESCRIPTION
Knex rollbacks where failing due to migrations attempting to drop columns with active constraints. 
Added catch blocks to each of the migrations to prevent the migrations or rollbacks from hanging.

Closes #145.

## Checklist

- [ ] Unit tests
- [ ] Code coverage checked
- [x] Coding standards
- [x] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
