### PR TITLE
Feature/apvs 380/claimant trusted

### DIFF
--- a/app/constants/auto-approval-rules-enum.js
+++ b/app/constants/auto-approval-rules-enum.js
@@ -72,6 +72,6 @@ module.exports = {
   IS_CLAIMANT_TRUSTED: {
     value: 'is-claimant-trusted',
     displayName: 'Is the claimant trusted?',
-    description: 'Claimant has been marked as untrusted by a case worker'
+    description: 'Auto-approval has been disabled for this Claimant by a case worker'
   }
 }

--- a/app/constants/auto-approval-rules-enum.js
+++ b/app/constants/auto-approval-rules-enum.js
@@ -68,5 +68,10 @@ module.exports = {
     value: 'has-claimed-less-than-max-times-this-month',
     displayName: 'Has claimed less than max times this month',
     description: 'Claimant has not claimed more than the maximum number of claims in a month'
+  },
+  IS_CLAIMANT_TRUSTED: {
+    value: 'is-claimant-trusted',
+    displayName: 'Is the claimant trusted?',
+    description: 'Claimant has been marked as untrusted by a case worker'
   }
 }

--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -22,6 +22,8 @@ const ClaimDeduction = require('../../services/domain/claim-deduction')
 const updateClaimOverpaymentStatus = require('../../services/data/update-claim-overpayment-status')
 const OverpaymentResponse = require('../../services/domain/overpayment-response')
 const closeAdvanceClaim = require('../../services/data/close-advance-claim')
+const updateEligibilityTrustedStatus = require('../../services/data/update-eligibility-trusted-status')
+const claimDecisionEnum = require('../../../app/constants/claim-decision-enum')
 const Promise = require('bluebird')
 
 var claimExpenses
@@ -156,6 +158,14 @@ function submitClaimDecision (req, res, claimExpenses) {
 
   return SubmitClaimResponse(req.params.claimId, claimDecision)
     .then(function () {
+      if (claimDecision.decision === claimDecisionEnum.APPROVED) {
+        var isTrusted = req.body['is-trusted'] === 'on'
+        var untrustedReason = req.body['untrusted-reason']
+
+        return updateEligibilityTrustedStatus(req.params.claimId, isTrusted, untrustedReason)
+      }
+    })
+    .then(function () {
       return res.redirect('/')
     })
 }
@@ -229,6 +239,7 @@ function requestNewPaymentDetails (req, res) {
 function renderViewClaimPage (claimId, res) {
   getIndividualClaimDetails(claimId)
     .then(function (data) {
+      console.dir(data)
       return res.render('./claim/view-claim', {
         title: 'APVS Claim',
         Claim: data.claim,

--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -239,7 +239,6 @@ function requestNewPaymentDetails (req, res) {
 function renderViewClaimPage (claimId, res) {
   getIndividualClaimDetails(claimId)
     .then(function (data) {
-      console.dir(data)
       return res.render('./claim/view-claim', {
         title: 'APVS Claim',
         Claim: data.claim,

--- a/app/services/data/get-individual-claim-details.js
+++ b/app/services/data/get-individual-claim-details.js
@@ -71,6 +71,9 @@ function getClaimantDetails (claimId) {
     .first(
       'Eligibility.Reference',
       'Eligibility.EligibilityId',
+      'Eligibility.IsTrusted',
+      'Eligibility.UntrustedReason',
+      'Eligibility.UntrustedDate',
       'Claim.ClaimId',
       'Claim.ClaimType',
       'Claim.IsAdvanceClaim',

--- a/app/services/data/update-eligibility-trusted-status.js
+++ b/app/services/data/update-eligibility-trusted-status.js
@@ -1,0 +1,25 @@
+const config = require('../../../knexfile').intweb
+const knex = require('knex')(config)
+const insertClaimEvent = require('./insert-claim-event')
+
+module.exports = function (claimId, isUntrusted, untrustedReason) {
+  return getEligibilityData(claimId)
+    .then(function (eligibilityData) {
+      return knex('Eligibility')
+        .where('EligibilityId', eligibilityData.EligibilityId)
+        .update({
+          IsUntrusted: isUntrusted,
+          UntrustedReason: untrustedReason
+        })
+        .then(function () {
+          return insertClaimEvent(eligibilityData.Reference, eligibilityData.EligibilityId, claimId, 'UPDATE-CLAIM-TRUSTED-STATUS', null, untrustedReason, null, true)
+        })
+    })
+}
+
+function getEligibilityData (claimId) {
+  return knex('Claim')
+    .where('ClaimId', claimId)
+    .first()
+    .select('EligibilityId', 'Reference')
+}

--- a/app/views/partials/view-claim/decision.html
+++ b/app/views/partials/view-claim/decision.html
@@ -23,6 +23,18 @@
         <textarea type="text" class="form-control" name="additionalInfoApprove">{{ claimDecision['additionalInfoApprove'] }}</textarea>
       </div>
 
+      <div class="form-group">
+        <label for='is-trusted' class="block-label" data-target="untrusted-reason-section">
+          <input type="checkbox" name='is-trusted' id='is-trusted' {% if Claim['IsTrusted'] === true %} checked {% endif %} />
+          <span>Allow auto-approval</span>
+        </label>
+        <div id='untrusted-reason-section' class='form-group {% if Claim['IsTrusted'] === true %} js-hidden {% endif %}'>
+          <br >
+          <label class='form-label-bold'>Reason for disabling auto-approval for this claimant</label>
+          <textarea type="text" class='form-control ' name="untrusted-reason" id='untrusted-reason'></textarea>
+        </div>
+      </div>
+
       <input type="submit" class="button" name="approve" id="approve-submit" value="Send confirmation email to claimant">
     </div>
 

--- a/app/views/partials/view-claim/warnings.html
+++ b/app/views/partials/view-claim/warnings.html
@@ -28,3 +28,11 @@
     <p>Reason: {{ Claim['OverpaymentReason'] }}</p>    
   </div>
 {% endif %}
+
+{% if Claim['IsTrusted'] === false %}
+  <div class="banner">
+    <p class="heading-small">Auto-approval has been switched off for this claimant</p> 
+    <p>Reason: {{ Claim['UntrustedReason'] }}</p> 
+    <p>Date: {{ getDateFormatted.shortDate(Claim['UntrustedDate']) }}</p>
+  </div>
+{% endif %}

--- a/migrations/20161220105521_add-trusted-claimant-fields-to-eligibility.js
+++ b/migrations/20161220105521_add-trusted-claimant-fields-to-eligibility.js
@@ -1,13 +1,15 @@
 exports.up = function (knex, Promise) {
   return knex.schema.table('Eligibility', function (table) {
-    table.boolean('IsUntrusted').defaultTo(false)
+    table.boolean('IsTrusted').defaultTo(true)
     table.string('UntrustedReason')
+    table.dateTime('UntrustedDate')
   })
 }
 
 exports.down = function (knex, Promise) {
   return knex.schema.table('Eligibility', function (table) {
-    table.dropColumn('IsUntrusted')
+    table.dropColumn('IsTrusted')
     table.dropColumn('UntrustedReason')
+    table.dropColumn('UntrustedDate')
   })
 }

--- a/migrations/20161220105521_add-trusted-claimant-fields-to-eligibility.js
+++ b/migrations/20161220105521_add-trusted-claimant-fields-to-eligibility.js
@@ -1,0 +1,13 @@
+exports.up = function (knex, Promise) {
+  return knex.schema.table('Eligibility', function (table) {
+    table.boolean('IsUntrusted').defaultTo(false)
+    table.string('UntrustedReason')
+  })
+}
+
+exports.down = function (knex, Promise) {
+  return knex.schema.table('Eligibility', function (table) {
+    table.dropColumn('IsUntrusted')
+    table.dropColumn('UntrustedReason')
+  })
+}

--- a/test/integration/services/data/test-update-eligibility-trusted-status.js
+++ b/test/integration/services/data/test-update-eligibility-trusted-status.js
@@ -1,58 +1,90 @@
 const expect = require('chai').expect
+const sinon = require('sinon')
+require('sinon-bluebird')
+const proxyquire = require('proxyquire')
 const config = require('../../../../knexfile').migrations
 const knex = require('knex')(config)
 const databaseHelper = require('../../../helpers/database-setup-for-tests')
 const dateFormatter = require('../../../../app/services/date-formatter')
-const updateEligibilityTrustedStatus = require('../../../../app/services/data/update-eligibility-trusted-status')
+
+var sandbox = sinon.sandbox.create()
+var stubInsertClaimEvent = sandbox.stub().resolves()
+
+const updateEligibilityTrustedStatus = proxyquire('../../../../app/services/data/update-eligibility-trusted-status', {
+  './insert-claim-event': stubInsertClaimEvent
+})
 
 const REFERENCE = 'UNTRUSTED'
 
-var eligibilityId
-var claimId
+var eligibilityId1
+var eligibilityId2
+var claimId1
+var claimId2
 
-describe('services/data/insert-claim-event', function () {
+describe('services/data/update-eligibility-trusted-status', function () {
+  beforeEach(function () {
+    sandbox.reset()
+  })
+
   before(function () {
     return databaseHelper.insertTestData(REFERENCE, dateFormatter.now().toDate(), 'Test').then(function (ids) {
-      claimId = ids.claimId
-      eligibilityId = ids.eligibilityId
+      claimId1 = ids.claimId
+      eligibilityId1 = ids.eligibilityId
+
+      return databaseHelper.insertTestData(REFERENCE, dateFormatter.now().toDate(), 'Test').then(function (ids2) {
+        claimId2 = ids2.claimId
+        eligibilityId2 = ids2.eligibilityId
+      })
     })
   })
 
   it('should set the eligibility to untrusted and create a claim event', function () {
-    var untrustedReason = 'untrusted reason'
-    var isUntrusted = true
-
-    return updateEligibilityTrustedStatus(claimId, isUntrusted, untrustedReason)
+    return setEligibilityTrusted(eligibilityId1, true)
       .then(function () {
-        return getEligibility(eligibilityId)
-          .then(function (eligibility) {
-            expect(eligibility.IsUntrusted).to.equal(isUntrusted)
-            expect(eligibility.UntrustedReason).to.equal(untrustedReason)
-          })
+        var untrustedReason = 'untrusted reason'
+        var isTrusted = false
+
+        return updateEligibilityTrustedStatus(claimId1, isTrusted, untrustedReason)
           .then(function () {
-            return getClaimEvent(claimId)
-              .then(function (claimEvent) {
-                expect(claimEvent.Event).to.equal('UPDATE-CLAIM-TRUSTED-STATUS')
+            return getEligibility(eligibilityId1)
+              .then(function (eligibility) {
+                expect(eligibility.IsTrusted).to.equal(isTrusted)
+                expect(eligibility.UntrustedReason).to.equal(untrustedReason)
+                expect(eligibility.UntrustedDate).to.not.be.null
+                expect(stubInsertClaimEvent.calledOnce).to.be.true
               })
           })
       })
   })
 
   it('should set the eligibility to trusted and create a claim event', function () {
-    var untrustedReason = null
-    var isUntrusted = false
-
-    return updateEligibilityTrustedStatus(claimId, isUntrusted, untrustedReason)
+    return setEligibilityTrusted(eligibilityId1, false)
       .then(function () {
-        return getEligibility(eligibilityId)
-          .then(function (eligibility) {
-            expect(eligibility.IsUntrusted).to.equal(isUntrusted)
-            expect(eligibility.UntrustedReason).to.equal(untrustedReason)
-          })
+        var untrustedReason = ''
+        var isTrusted = true
+
+        return updateEligibilityTrustedStatus(claimId1, isTrusted, untrustedReason)
           .then(function () {
-            return getClaimEvent(claimId)
-              .then(function (claimEvent) {
-                expect(claimEvent.Event).to.equal('UPDATE-CLAIM-TRUSTED-STATUS')
+            return getEligibility(eligibilityId1)
+              .then(function (eligibility) {
+                expect(eligibility.IsTrusted).to.equal(isTrusted)
+                expect(eligibility.UntrustedReason).to.be.null
+                expect(eligibility.UntrustedDate).to.be.null
+                expect(stubInsertClaimEvent.calledOnce).to.be.true
+              })
+          })
+      })
+  })
+
+  it('should do nothing if current and new IsTrusted values are the same', function () {
+    return setEligibilityTrusted(eligibilityId2, true)
+      .then(function () {
+        return updateEligibilityTrustedStatus(claimId2, true, null)
+          .then(function () {
+            return getEligibility(eligibilityId2)
+              .then(function (eligibility) {
+                expect(eligibility.IsTrusted).to.equal(true)
+                expect(stubInsertClaimEvent.notCalled).to.be.true
               })
           })
       })
@@ -68,8 +100,10 @@ function getEligibility (eligibilityId) {
     .where('EligibilityId', eligibilityId)
 }
 
-function getClaimEvent (claimId) {
-  return knex('IntSchema.ClaimEvent').first()
-    .where('ClaimId', claimId)
-    .orderBy('DateAdded', 'desc')
+function setEligibilityTrusted (eligibilityId, isTrusted) {
+  return knex('Eligibility')
+    .where('EligibilityId', eligibilityId)
+    .update({
+      'IsTrusted': isTrusted
+    })
 }

--- a/test/integration/services/data/test-update-eligibility-trusted-status.js
+++ b/test/integration/services/data/test-update-eligibility-trusted-status.js
@@ -1,0 +1,75 @@
+const expect = require('chai').expect
+const config = require('../../../../knexfile').migrations
+const knex = require('knex')(config)
+const databaseHelper = require('../../../helpers/database-setup-for-tests')
+const dateFormatter = require('../../../../app/services/date-formatter')
+const updateEligibilityTrustedStatus = require('../../../../app/services/data/update-eligibility-trusted-status')
+
+const REFERENCE = 'UNTRUSTED'
+
+var eligibilityId
+var claimId
+
+describe('services/data/insert-claim-event', function () {
+  before(function () {
+    return databaseHelper.insertTestData(REFERENCE, dateFormatter.now().toDate(), 'Test').then(function (ids) {
+      claimId = ids.claimId
+      eligibilityId = ids.eligibilityId
+    })
+  })
+
+  it('should set the eligibility to untrusted and create a claim event', function () {
+    var untrustedReason = 'untrusted reason'
+    var isUntrusted = true
+
+    return updateEligibilityTrustedStatus(claimId, isUntrusted, untrustedReason)
+      .then(function () {
+        return getEligibility(eligibilityId)
+          .then(function (eligibility) {
+            expect(eligibility.IsUntrusted).to.equal(isUntrusted)
+            expect(eligibility.UntrustedReason).to.equal(untrustedReason)
+          })
+          .then(function () {
+            return getClaimEvent(claimId)
+              .then(function (claimEvent) {
+                expect(claimEvent.Event).to.equal('UPDATE-CLAIM-TRUSTED-STATUS')
+              })
+          })
+      })
+  })
+
+  it('should set the eligibility to trusted and create a claim event', function () {
+    var untrustedReason = null
+    var isUntrusted = false
+
+    return updateEligibilityTrustedStatus(claimId, isUntrusted, untrustedReason)
+      .then(function () {
+        return getEligibility(eligibilityId)
+          .then(function (eligibility) {
+            expect(eligibility.IsUntrusted).to.equal(isUntrusted)
+            expect(eligibility.UntrustedReason).to.equal(untrustedReason)
+          })
+          .then(function () {
+            return getClaimEvent(claimId)
+              .then(function (claimEvent) {
+                expect(claimEvent.Event).to.equal('UPDATE-CLAIM-TRUSTED-STATUS')
+              })
+          })
+      })
+  })
+
+  after(function () {
+    return databaseHelper.deleteAll(REFERENCE)
+  })
+})
+
+function getEligibility (eligibilityId) {
+  return knex('IntSchema.Eligibility').first()
+    .where('EligibilityId', eligibilityId)
+}
+
+function getClaimEvent (claimId) {
+  return knex('IntSchema.ClaimEvent').first()
+    .where('ClaimId', claimId)
+    .orderBy('DateAdded', 'desc')
+}


### PR DESCRIPTION
-  Added new fields to Eligibility table that determine whether a claimant is eligible for auto-approval (IsTrusted, UntrustedReason, UntrustedDate)
- Added new fields to view-claim page to allow claimant to set trusted status when approving a claim
- Added warning to top of view-claim page that will display if a claimant has had auto-approval disabled by a caseworker

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated