### PR TITLE
Chore/display-manually-approved-amount-when-errors

### DIFF
--- a/app/routes/helpers/merge-claim-expenses-with-submitted-responses.js
+++ b/app/routes/helpers/merge-claim-expenses-with-submitted-responses.js
@@ -20,7 +20,6 @@ module.exports = function (oldData, nonPersistedData) {
       }
     }
   })
-  
   newClaimExpenseData = oldData
   return newClaimExpenseData
 }

--- a/app/routes/helpers/merge-claim-expenses-with-submitted-responses.js
+++ b/app/routes/helpers/merge-claim-expenses-with-submitted-responses.js
@@ -12,7 +12,7 @@ module.exports = function (oldData, nonPersistedData) {
   oldData.forEach(function (expense) {
     var postedClaimExpenseResponse = claimExpensesById[expense.ClaimExpenseId.toString()]
     expense.Status = postedClaimExpenseResponse.status
-    if (expense.Status === claimDecisionEnum.APPROVED_DIFF_AMOUNT) {
+    if (expense.Status === claimDecisionEnum.APPROVED_DIFF_AMOUNT || expense.Status === claimDecisionEnum.MANUALLY_PROCESSED) {
       expense.ApprovedCost = postedClaimExpenseResponse.approvedCost
       if (!Validator.isCurrency(postedClaimExpenseResponse.approvedCost) || !Validator.isGreaterThanZero(postedClaimExpenseResponse.approvedCost) ||
         !Validator.isLessThanMaximumDifferentApprovedAmount(postedClaimExpenseResponse.approvedCost)) {
@@ -20,7 +20,6 @@ module.exports = function (oldData, nonPersistedData) {
       }
     }
   })
-
   newClaimExpenseData = oldData
   return newClaimExpenseData
 }

--- a/app/routes/helpers/merge-claim-expenses-with-submitted-responses.js
+++ b/app/routes/helpers/merge-claim-expenses-with-submitted-responses.js
@@ -20,6 +20,7 @@ module.exports = function (oldData, nonPersistedData) {
       }
     }
   })
+  
   newClaimExpenseData = oldData
   return newClaimExpenseData
 }

--- a/app/routes/helpers/merge-claim-expenses-with-submitted-responses.js
+++ b/app/routes/helpers/merge-claim-expenses-with-submitted-responses.js
@@ -20,6 +20,7 @@ module.exports = function (oldData, nonPersistedData) {
       }
     }
   })
+
   newClaimExpenseData = oldData
   return newClaimExpenseData
 }


### PR DESCRIPTION
Fixed the issue on internal site for advanced claim. Manually processed amount was not getting put back into the field when doing validation.

## Checklist

- [ ] Unit tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
