### PR TITLE
Updated in progress query for dashboard

### DIFF
--- a/app/constants/claim-status-enum.js
+++ b/app/constants/claim-status-enum.js
@@ -30,5 +30,9 @@ module.exports = {
   REQUEST_INFO_PAYMENT: {
     value: 'REQUEST-INFO-PAYMENT',
     closed: false
+  },
+  REQUEST_INFORMATION: {
+    value: 'REQUEST-INFORMATION',
+    closed: false
   }
 }

--- a/app/services/data/dashboard/get-in-progress-claim-count.js
+++ b/app/services/data/dashboard/get-in-progress-claim-count.js
@@ -7,7 +7,12 @@ module.exports = function (filter) {
   return applyFilter(
       knex('Claim')
         .count('ClaimId AS Count')
-        .whereIn('Status', [ claimStatusEnum.NEW.value, claimStatusEnum.UPDATED.value ]),
+        .whereIn('Status', [
+          claimStatusEnum.NEW.value,
+          claimStatusEnum.UPDATED.value,
+          claimStatusEnum.REQUEST_INFORMATION.value,
+          claimStatusEnum.REQUEST_INFO_PAYMENT.value
+        ]),
       filter
     )
 }

--- a/test/integration/services/data/dashboard/test-get-in-progress-claim-count.js
+++ b/test/integration/services/data/dashboard/test-get-in-progress-claim-count.js
@@ -55,8 +55,8 @@ describe('services/data/dashboard/get-in-progress-claim-count', function () {
 
               promises.push(databaseHelper.insertClaim(claimId2, eligibilityId, reference, yesterday, claimStatusEnum.NEW.value, false))
               promises.push(databaseHelper.insertClaim(claimId3, eligibilityId, reference, lastWeek, claimStatusEnum.UPDATED.value, false))
-              promises.push(databaseHelper.insertClaim(claimId4, eligibilityId, reference, oneMonthAgo, claimStatusEnum.NEW.value, false))
-              promises.push(databaseHelper.insertClaim(claimId5, eligibilityId, reference, twoMonthsAgo, claimStatusEnum.UPDATED.value, false))
+              promises.push(databaseHelper.insertClaim(claimId4, eligibilityId, reference, oneMonthAgo, claimStatusEnum.REQUEST_INFORMATION.value, false))
+              promises.push(databaseHelper.insertClaim(claimId5, eligibilityId, reference, twoMonthsAgo, claimStatusEnum.REQUEST_INFO_PAYMENT.value, false))
               promises.push(databaseHelper.insertClaim(claimId6, eligibilityId, reference, threeMonthsAgo, claimStatusEnum.NEW.value, false))
               promises.push(databaseHelper.insertClaim(claimId7, eligibilityId, reference, fourMonthsAgo, claimStatusEnum.UPDATED.value, false))
               promises.push(databaseHelper.insertClaim(claimId8, eligibilityId, reference, yesterday, claimStatusEnum.APPROVED.value, false))


### PR DESCRIPTION
Added claims with a status of REQUEST-INFO-PAYMENT or REQUEST-INFORMATION to the In Progress count on the dashboard

Resolves the dashboard part of issue #193 