### PR TITLE
Fix for claim expense validation error when cost ends in 0

### DIFF
--- a/app/services/data/get-individual-claim-details.js
+++ b/app/services/data/get-individual-claim-details.js
@@ -139,6 +139,13 @@ function getClaimExpenses (claimId) {
         .on('ClaimExpense.IsEnabled', 'ClaimDocument.IsEnabled')
     })
     .orderBy('ClaimExpense.ClaimExpenseId')
+    .then(function (claimExpenses) {
+      claimExpenses.forEach(function (claimExpense) {
+        claimExpense.Cost = Number(claimExpense.Cost).toFixed(2)
+      })
+
+      return claimExpenses
+    })
 }
 
 function getClaimDeductions (claimId) {

--- a/test/integration/services/data/test-get-individual-claim-details.js
+++ b/test/integration/services/data/test-get-individual-claim-details.js
@@ -42,7 +42,7 @@ describe('services/data/get-individual-claim-details', function () {
           expect(result.claim.NameOfPrison).to.equal(testData.Prisoner.NameOfPrison)
           expect(result.claimExpenses[0].ExpenseType).to.equal(testData.ClaimExpenses[0].ExpenseType)
           expect(result.claimExpenses[0].DocumentStatus).to.equal(testData.ClaimDocument['expense'].DocumentStatus)
-          expect(result.claimExpenses[1].Cost).to.equal(testData.ClaimExpenses[1].Cost)
+          expect(result.claimExpenses[1].Cost).to.equal(Number(testData.ClaimExpenses[1].Cost).toFixed(2))
           expect(result.claim.visitConfirmation.DocumentStatus).to.equal(testData.ClaimDocument['visit-confirmation'].DocumentStatus)
           expect(result.claim.benefitDocument[0].DocumentStatus).to.equal(testData.ClaimDocument['benefit'].DocumentStatus)
           expect(result.claimChild[0].FirstName).to.equal(testData.ClaimChild[0].FirstName)


### PR DESCRIPTION
Updated get-individual-claim-details so that all claim expense costs are returned in the correct format (2 decimal places)

Closes #192 

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
