### PR TITLE
Chore/fix benefit document association with claim

### DIFF
--- a/app/routes/claim/file-upload.js
+++ b/app/routes/claim/file-upload.js
@@ -17,7 +17,13 @@ module.exports = function (router) {
     csrfToken = generateCSRFToken(req)
 
     if (DocumentTypeEnum.hasOwnProperty(req.params.documentType)) {
-      DirectoryCheck(`${req.params.referenceId}-${req.query.eligibilityId}`, req.query.claimExpenseId, req.params.documentType)
+      var claimId
+      if (req.query.document === 'VISIT_CONFIRMATION' || req.query.document === 'RECEIPT') {
+        claimId = req.params.claimId
+      } else {
+        claimId = null
+      }
+      DirectoryCheck(`${req.params.referenceId}-${req.query.eligibilityId}`, claimId, req.query.claimExpenseId, req.params.documentType)
       return res.render('claim/file-upload', {
         claimType: req.params.claimType,
         document: req.params.documentType,

--- a/app/routes/claim/file-upload.js
+++ b/app/routes/claim/file-upload.js
@@ -17,7 +17,7 @@ module.exports = function (router) {
     csrfToken = generateCSRFToken(req)
 
     if (DocumentTypeEnum.hasOwnProperty(req.params.documentType)) {
-      DirectoryCheck(`${req.params.referenceId}-${req.query.eligibilityId}`, req.params.claimId, req.query.claimExpenseId, req.params.documentType)
+      DirectoryCheck(`${req.params.referenceId}-${req.query.eligibilityId}`, req.query.claimExpenseId, req.params.documentType)
       return res.render('claim/file-upload', {
         claimType: req.params.claimType,
         document: req.params.documentType,

--- a/app/services/data/get-individual-claim-details.js
+++ b/app/services/data/get-individual-claim-details.js
@@ -21,7 +21,7 @@ module.exports = function (claimId) {
       claim = claimData
       reference = claim.Reference
       claim.lastUpdatedHidden = moment(claim.LastUpdated)
-      return getClaimDocuments(claimId)
+      return getClaimDocuments(claimId, reference, claim.EligibilityId)
     })
     .then(function (claimDocumentData) {
       claim = appendClaimDocumentsToClaim(claim, claimDocumentData)
@@ -116,9 +116,15 @@ function getClaimantDetails (claimId) {
       'Prisoner.NomisCheck')
 }
 
-function getClaimDocuments (claimId) {
+function getClaimDocuments (claimId, reference, eligibilityId) {
   return knex('ClaimDocument')
     .where({'ClaimDocument.ClaimId': claimId, 'ClaimDocument.IsEnabled': true, 'ClaimDocument.ClaimExpenseId': null})
+    .orWhere({
+      'ClaimDocument.ClaimId': null,
+      'ClaimDocument.Reference': reference,
+      'ClaimDocument.EligibilityId': eligibilityId,
+      'ClaimDocument.IsEnabled': true,
+      'ClaimDocument.ClaimExpenseId': null})
     .select(
       'ClaimDocument.ClaimDocumentId',
       'ClaimDocument.DocumentStatus',

--- a/app/services/directory-check.js
+++ b/app/services/directory-check.js
@@ -2,12 +2,12 @@ const config = require('../../config')
 var fs = require('fs')
 var mkdirp = require('mkdirp')
 
-module.exports = function (referenceId, claimId, claimExpenseId, documentType) {
+module.exports = function (referenceId, claimExpenseId, documentType) {
   var path
   if (!claimExpenseId) {
-    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${claimId}/${documentType}`
+    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${documentType}`
   } else {
-    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${claimId}/${claimExpenseId}/${documentType}`
+    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${claimExpenseId}/${documentType}`
   }
   if (!fs.existsSync(path)) {
     mkdirp.sync(path)

--- a/app/services/directory-check.js
+++ b/app/services/directory-check.js
@@ -2,12 +2,14 @@ const config = require('../../config')
 var fs = require('fs')
 var mkdirp = require('mkdirp')
 
-module.exports = function (referenceId, claimExpenseId, documentType) {
+module.exports = function (referenceId, claimId, claimExpenseId, documentType) {
   var path
-  if (!claimExpenseId) {
+  if (!claimId) {
     path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${documentType}`
+  } else if (!claimExpenseId) {
+    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${claimId}/${documentType}`
   } else {
-    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${claimExpenseId}/${documentType}`
+    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${claimId}/${claimExpenseId}/${documentType}`
   }
   if (!fs.existsSync(path)) {
     mkdirp.sync(path)

--- a/app/services/upload.js
+++ b/app/services/upload.js
@@ -11,9 +11,9 @@ const allowedFileTypes = [ 'image/png', 'image/jpeg', 'application/pdf' ]
 var storage = multer.diskStorage({
   destination: function (req, file, cb) {
     if (req.query.claimExpenseId) {
-      cb(null, `${config.FILE_UPLOAD_LOCATION}/${req.params.referenceId}-${req.query.eligibilityId}/${req.params.claimId}/${req.query.claimExpenseId}/${req.params.documentType}`)
+      cb(null, `${config.FILE_UPLOAD_LOCATION}/${req.params.referenceId}-${req.query.eligibilityId}/${req.query.claimExpenseId}/${req.params.documentType}`)
     } else {
-      cb(null, `${config.FILE_UPLOAD_LOCATION}/${req.params.referenceId}-${req.query.eligibilityId}/${req.params.claimId}/${req.params.documentType}`)
+      cb(null, `${config.FILE_UPLOAD_LOCATION}/${req.params.referenceId}-${req.query.eligibilityId}/${req.params.documentType}`)
     }
   },
   filename: function (req, file, cb) {

--- a/app/services/upload.js
+++ b/app/services/upload.js
@@ -10,7 +10,7 @@ const allowedFileTypes = [ 'image/png', 'image/jpeg', 'application/pdf' ]
 
 var storage = multer.diskStorage({
   destination: function (req, file, cb) {
-    if (req.query.document !== 'VISIT_CONFIRMATION' || req.query.document !== 'RECEIPT') {
+    if (req.query.document !== 'VISIT_CONFIRMATION' && req.query.document !== 'RECEIPT') {
       cb(null, `${config.FILE_UPLOAD_LOCATION}/${req.params.referenceId}-${req.query.eligibilityId}${req.params.documentType}`)
     } else if (req.query.claimExpenseId) {
       cb(null, `${config.FILE_UPLOAD_LOCATION}/${req.params.referenceId}-${req.query.eligibilityId}/${req.params.claimId}/${req.query.claimExpenseId}/${req.params.documentType}`)

--- a/app/services/upload.js
+++ b/app/services/upload.js
@@ -10,10 +10,12 @@ const allowedFileTypes = [ 'image/png', 'image/jpeg', 'application/pdf' ]
 
 var storage = multer.diskStorage({
   destination: function (req, file, cb) {
-    if (req.query.claimExpenseId) {
-      cb(null, `${config.FILE_UPLOAD_LOCATION}/${req.params.referenceId}-${req.query.eligibilityId}/${req.query.claimExpenseId}/${req.params.documentType}`)
+    if (req.query.document !== 'VISIT_CONFIRMATION' || req.query.document !== 'RECEIPT') {
+      cb(null, `${config.FILE_UPLOAD_LOCATION}/${req.params.referenceId}-${req.query.eligibilityId}${req.params.documentType}`)
+    } else if (req.query.claimExpenseId) {
+      cb(null, `${config.FILE_UPLOAD_LOCATION}/${req.params.referenceId}-${req.query.eligibilityId}/${req.params.claimId}/${req.query.claimExpenseId}/${req.params.documentType}`)
     } else {
-      cb(null, `${config.FILE_UPLOAD_LOCATION}/${req.params.referenceId}-${req.query.eligibilityId}/${req.params.documentType}`)
+      cb(null, `${config.FILE_UPLOAD_LOCATION}/${req.params.referenceId}-${req.query.eligibilityId}/${req.params.claimId}/${req.params.documentType}`)
     }
   },
   filename: function (req, file, cb) {

--- a/migrations/20170113152925_remove-not-null-on-claimId-claim-document.js
+++ b/migrations/20170113152925_remove-not-null-on-claimId-claim-document.js
@@ -1,0 +1,15 @@
+exports.up = function (knex, Promise) {
+  return knex.raw('ALTER TABLE IntSchema.ClaimDocument ALTER COLUMN ClaimId INT NULL')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
+}
+
+exports.down = function (knex, Promise) {
+  return knex.raw('ALTER TABLE IntSchema.ClaimDocument ALTER COLUMN ClaimId INT NOT NULL')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
+}

--- a/seeds/add-get-claim-documents-historic-claim.js
+++ b/seeds/add-get-claim-documents-historic-claim.js
@@ -1,7 +1,7 @@
 const config = require('../config')
 
 /**
- * Adds a table function to the IntSchema that retrieves all claim documents by reference and claimId and grants the
+ * Adds a table function to the IntSchema that retrieves all claim documents by reference, eligibilityId and claimId and grants the
  * external web user permissions to call it.
  */
 exports.seed = function (knex, Promise) {
@@ -11,7 +11,7 @@ exports.seed = function (knex, Promise) {
       return knex.schema
         .raw(
           `
-            CREATE FUNCTION IntSchema.getClaimDocumentsHistoricClaim(@reference varchar(7), @claimId int)
+            CREATE FUNCTION IntSchema.getClaimDocumentsHistoricClaim(@reference varchar(7), @eligibilityId int, @claimId int)
             RETURNS TABLE
             AS
             RETURN
@@ -23,6 +23,7 @@ exports.seed = function (knex, Promise) {
               FROM IntSchema.ClaimDocument AS ClaimDocument
               WHERE
                 ClaimDocument.Reference = @reference AND
+                ClaimDocument.EligibilityId = @eligibilityId AND
                 ClaimDocument.ClaimId = @claimId
             )
           `

--- a/seeds/add-get-claim-documents-historic-claim.js
+++ b/seeds/add-get-claim-documents-historic-claim.js
@@ -24,7 +24,8 @@ exports.seed = function (knex, Promise) {
               WHERE
                 ClaimDocument.Reference = @reference AND
                 ClaimDocument.EligibilityId = @eligibilityId AND
-                ClaimDocument.ClaimId = @claimId
+                (ClaimDocument.ClaimId = @claimId OR
+                ClaimDocument.ClaimId IS NULL)
             )
           `
         )

--- a/seeds/add-get-historic-claims-function.js
+++ b/seeds/add-get-historic-claims-function.js
@@ -23,6 +23,7 @@ exports.seed = function (knex, Promise) {
                 Claim.ClaimId,
                 Claim.DateOfJourney,
                 Claim.Status,
+                Claim.EligibilityId,
                 Visitor.DateOfBirth,
                 Prisoner.FirstName,
                 Prisoner.LastName,

--- a/test/unit/services/test-directory-check.js
+++ b/test/unit/services/test-directory-check.js
@@ -2,18 +2,18 @@ var expect = require('chai').expect
 var directoryCheck = require('../../../app/services/directory-check')
 const config = require('../../../config')
 var fs = require('fs')
-var normalDocumentPath = `${config.FILE_UPLOAD_LOCATION}/1/1/1`
-var claimExpensePath = `${config.FILE_UPLOAD_LOCATION}/1/1/1/1`
+var normalDocumentPath = `${config.FILE_UPLOAD_LOCATION}/1/1`
+var claimExpensePath = `${config.FILE_UPLOAD_LOCATION}/1/1/1`
 
 describe('services/directory-check', function () {
   it('check and see creates a directory is created for a doc without claimExpenseId', function () {
-    directoryCheck('1', '1', undefined, '1')
+    directoryCheck('1', undefined, '1')
     expect(fs.existsSync(normalDocumentPath)).to.equal(true)
     expect(fs.existsSync(claimExpensePath)).to.equal(false)
   })
 
   it('check and see creates a directory is created for a doc with claimExpenseId', function () {
-    directoryCheck('1', '1', '1', '1')
+    directoryCheck('1', '1', '1')
     expect(fs.existsSync(claimExpensePath)).to.equal(true)
   })
 
@@ -22,7 +22,6 @@ describe('services/directory-check', function () {
       fs.rmdirSync(claimExpensePath)
     }
     fs.rmdirSync(normalDocumentPath)
-    fs.rmdirSync(`${config.FILE_UPLOAD_LOCATION}/1/1`)
     fs.rmdirSync(`${config.FILE_UPLOAD_LOCATION}/1`)
   })
 })

--- a/test/unit/services/test-directory-check.js
+++ b/test/unit/services/test-directory-check.js
@@ -2,26 +2,42 @@ var expect = require('chai').expect
 var directoryCheck = require('../../../app/services/directory-check')
 const config = require('../../../config')
 var fs = require('fs')
-var normalDocumentPath = `${config.FILE_UPLOAD_LOCATION}/1/1`
-var claimExpensePath = `${config.FILE_UPLOAD_LOCATION}/1/1/1`
+var benefitPath = `${config.FILE_UPLOAD_LOCATION}/REFNUM1/hc2`
+var visitConfirmationPath = `${config.FILE_UPLOAD_LOCATION}/REFNUM1/1234/VISIT_CONFIRMATION`
+var claimExpensePath = `${config.FILE_UPLOAD_LOCATION}/REFNUM1/1234/5678/RECEIPT`
 
 describe('services/directory-check', function () {
   it('check and see creates a directory is created for a doc without claimExpenseId', function () {
-    directoryCheck('1', undefined, '1')
-    expect(fs.existsSync(normalDocumentPath)).to.equal(true)
+    directoryCheck('REFNUM1', '1234', undefined, 'VISIT_CONFIRMATION')
+    expect(fs.existsSync(visitConfirmationPath)).to.equal(true)
     expect(fs.existsSync(claimExpensePath)).to.equal(false)
   })
 
   it('check and see creates a directory is created for a doc with claimExpenseId', function () {
-    directoryCheck('1', '1', '1')
+    directoryCheck('REFNUM1', '1234', '5678', 'RECEIPT')
+    expect(fs.existsSync(claimExpensePath)).to.equal(true)
+  })
+
+  it('check and see creates a directory is created for a doc without claimId ie benefit documents', function () {
+    directoryCheck('REFNUM1', null, undefined, 'hc2')
     expect(fs.existsSync(claimExpensePath)).to.equal(true)
   })
 
   after(function () {
     if (fs.existsSync(claimExpensePath)) {
       fs.rmdirSync(claimExpensePath)
+      fs.rmdirSync(`${config.FILE_UPLOAD_LOCATION}/REFNUM1/1234/5678`)
     }
-    fs.rmdirSync(normalDocumentPath)
-    fs.rmdirSync(`${config.FILE_UPLOAD_LOCATION}/1`)
+    if (fs.existsSync(visitConfirmationPath)) {
+      fs.rmdirSync(visitConfirmationPath)
+    }
+    if (fs.existsSync(benefitPath)) {
+      fs.rmdirSync(benefitPath)
+    }
+
+    if (fs.existsSync(`${config.FILE_UPLOAD_LOCATION}/REFNUM1/1234`)) {
+      fs.rmdirSync(`${config.FILE_UPLOAD_LOCATION}/REFNUM1/1234`)
+    }
+    fs.rmdirSync(`${config.FILE_UPLOAD_LOCATION}/REFNUM1`)
   })
 })


### PR DESCRIPTION
Updated to now associate claims with visitor and now to each claim by claimId
 
* Updated table function for claim documents to look for claimId null to get benefit docs
* Updated historic claim table function so it returns eligibilityId as it is needed for calls to get benefit docs
* Updated check directory to now use claimId
* Updated all fetches (view claim and claim summary) to look for claimId null to get benefit docs

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards
