### PR TITLE
chore - update claim expense table function

### DIFF
--- a/seeds/add-get-claim-expense-by-id-or-last-approved.js
+++ b/seeds/add-get-claim-expense-by-id-or-last-approved.js
@@ -51,7 +51,11 @@ exports.seed = function (knex, Promise) {
                   )
               ) 
               AND ClaimExpense.IsEnabled = 1
-              AND ClaimExpense.Status != 'REJECTED'
+              AND
+                (
+                  ClaimExpense.Status IS NULL OR
+                  ClaimExpense.Status != 'REJECTED'
+                )
             )
           `
         )


### PR DESCRIPTION
Check for claim expenses with Status set to null as this is the case in our integration tests.

We should also return expenses with a status of null when a claimant returns to the view claim page before its been processed.

## Checklist

- [ ] Unit tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
#