### PR TITLE
chore - fix e2e test authentication issue

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -20,7 +20,7 @@
         <input type="text" name="q" class="form-control" id="input-search-query">
       </label>
       <input type="submit" class="button" value="Search" id="search">
-      <a href="/advanced-search-input" class="link margin-left">Advanced Search</a>
+      <a id="advanced-search" href="/advanced-search-input" class="link margin-left">Advanced Search</a>
     </form>
     <br>
   </div>

--- a/test/e2e/advanced-search.js
+++ b/test/e2e/advanced-search.js
@@ -13,53 +13,57 @@ var reference1ClaimId
 var reference2ClaimId
 var yesterday
 var tomorrow
+var promises = []
 
 describe('Advanced search flow', () => {
   before(function () {
     date = dateFormatter.now()
     yesterday = moment(date).subtract(1, 'day')
     tomorrow = moment(date).add(1, 'day')
-    return databaseHelper.insertTestData(reference1, date.toDate(), 'APPROVED')
-      .then(function (ids) {
-        reference1ClaimId = ids.claimId
-
-        var reference1Update = knex('Claim')
-          .update({
-            'AssistedDigitalCaseworker': 'test@test.com',
-            'DateOfJourney': date.toDate(),
-            'DateReviewed': date.toDate(),
-            'BankPaymentAmount': '12'
-          })
-          .where('Reference', reference1)
-
-        var reference2Insert = databaseHelper.insertTestData(reference2, date.toDate(), 'REJECTED')
-          .then(function (ids) {
-            reference2ClaimId = ids.claimId
-          })
-
-        return Promise.all([reference1Update, reference2Insert])
-          .then(function () {
-            return knex('Claim')
-              .update({
-                'DateReviewed': date.toDate()
-              })
-          })
-      })
-    .then(function () {
-      if (config.AUTHENTICATION_ENABLED === 'true') {
-        return browser.url(config.TOKEN_HOST)
+    if (config.AUTHENTICATION_ENABLED === 'true') {
+      promises.push(
+        browser.url(config.TOKEN_HOST)
           .waitForExist('#user_email')
           .setValue('#user_email', config.TEST_SSO_EMAIL)
           .setValue('#user_password', config.TEST_SSO_PASSWORD)
           .click('[name="commit"]')
           .waitForExist('[href="/users/sign_out"]')
-      }
-    })
+      )
+    }
+    promises.push(
+      databaseHelper.insertTestData(reference1, date.toDate(), 'APPROVED')
+        .then(function (ids) {
+          reference1ClaimId = ids.claimId
+
+          var reference1Update = knex('Claim')
+            .update({
+              'AssistedDigitalCaseworker': 'test@test.com',
+              'DateOfJourney': date.toDate(),
+              'DateReviewed': date.toDate(),
+              'BankPaymentAmount': '12'
+            })
+            .where('Reference', reference1)
+
+          var reference2Insert = databaseHelper.insertTestData(reference2, date.toDate(), 'REJECTED')
+            .then(function (ids) {
+              reference2ClaimId = ids.claimId
+            })
+
+          return Promise.all([reference1Update, reference2Insert])
+            .then(function () {
+              return knex('Claim')
+                .update({
+                  'DateReviewed': date.toDate()
+                })
+            })
+        })
+    )
+    return Promise.all(promises)
   })
 
   it('should display the advanced search page and return existing claims', () => {
-    return browser.url('/advanced-search-input')
-
+    return browser.url('/')
+      .click('#advanced-search')
       .waitForExist('#advanced-search-submit')
 
       .setValue('#reference', '333333')

--- a/test/e2e/advanced-search.js
+++ b/test/e2e/advanced-search.js
@@ -23,7 +23,7 @@ describe('Advanced search flow', () => {
       .then(function (ids) {
         reference1ClaimId = ids.claimId
 
-        var reference1Update = knex('Claim')
+        var reference1Update = knex('IntSchema.Claim')
           .update({
             'AssistedDigitalCaseworker': 'test@test.com',
             'DateOfJourney': date.toDate(),
@@ -39,11 +39,11 @@ describe('Advanced search flow', () => {
 
         return Promise.all([reference1Update, reference2Insert])
           .then(function () {
-            return knex('Claim')
+            return knex('IntSchema.Claim')
               .update({
                 'DateReviewed': date.toDate()
               })
-              .where('Reference', reference1)
+              .where('Reference', reference2)
           })
       })
     .then(function () {


### PR DESCRIPTION
chore - fix advanced search e2e test authentication issue

After testing on Jenkins it seems checking for authentication sooner (rather than after all the DB inserts are done) resolves the current issue.

Also changed the test to go to the index page and then click on the advanced search link. Going straight to the advanced search page didn't seem to work on sauce labs.

## Checklist

- [ ] Unit tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
