### PR TITLE
Preserve inputs when adding/removing deductions, or uploading files

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -12,10 +12,26 @@ const onFinished = require('on-finished')
 const authentication = require('./authentication')
 const cookieParser = require('cookie-parser')
 const csurf = require('csurf')
+const session = require('express-session')
 const csrfExcludeRoutes = require('./constants/csrf-exclude-routes')
 const config = require('../config')
 
 var app = express()
+
+// Using local session storage
+var sessionOptions = {
+  secret: config.SESSION_SECRET,
+  cookie: {},
+  resave: true,
+  saveUninitialized: true
+}
+
+if (app.get('env') === 'production') {
+  app.set('trust proxy', 1)
+  sessionOptions.cookie.secure = true
+}
+
+app.use(session(sessionOptions))
 
 authentication(app)
 

--- a/app/authentication.js
+++ b/app/authentication.js
@@ -1,26 +1,10 @@
 const config = require('../config')
-const session = require('express-session')
 const passport = require('passport')
 const OAuth2Strategy = require('passport-oauth2').Strategy
 const request = require('request')
 
 module.exports = function (app) {
   if (config.AUTHENTICATION_ENABLED === 'true') {
-    // Using local session storage
-    var sessionOptions = {
-      secret: config.SESSION_SECRET,
-      cookie: {},
-      resave: true,
-      saveUninitialized: true
-    }
-
-    if (app.get('env') === 'production') {
-      app.set('trust proxy', 1)
-      sessionOptions.cookie.secure = true
-    }
-
-    app.use(session(sessionOptions))
-
     app.use(passport.initialize())
     app.use(passport.session())
 

--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -82,7 +82,10 @@ module.exports = function (router) {
   })
 
   router.post('/claim/:claimId/add-deduction', function (req, res, next) {
+    delete req.session.formData.deductionType
+    delete req.session.formData.deductionAmount
     req.session.formData = parseFormData(req.body)
+
     return validatePostRequest(req, res, next, function () {
       var deductionType = req.body.deductionType
       var amount = Number(req.body.deductionAmount).toFixed(2)
@@ -90,8 +93,6 @@ module.exports = function (router) {
 
       return insertDeduction(req.params.claimId, claimDeduction)
         .then(function () {
-          delete req.session.formData.deductionType
-          delete req.session.formData.deductionAmount
           return res.redirect(`/claim/${req.params.claimId}`)
         })
     })

--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -245,6 +245,9 @@ function parseFormData (formData) {
 }
 
 function renderViewClaimPage (claimId, res, req) {
+  var formData = req.session.formData
+  delete req.session.formData
+
   return getIndividualClaimDetails(claimId)
     .then(function (data) {
       return res.render('./claim/view-claim', {
@@ -265,12 +268,15 @@ function renderViewClaimPage (claimId, res, req) {
         deductions: data.deductions,
         overpaidClaims: data.overpaidClaims,
         claimDecisionEnum: claimDecisionEnum,
-        formData: req.session.formData
+        formData: formData
       })
     })
 }
 
 function handleError (error, req, res, updateConflict, next) {
+  var formData = req.session.formData
+  delete req.session.formData
+
   if (error instanceof ValidationError) {
     return getIndividualClaimDetails(req.params.claimId)
       .then(function (data) {
@@ -300,7 +306,7 @@ function handleError (error, req, res, updateConflict, next) {
           overpaidClaims: data.overpaidClaims,
           claimDecisionEnum: claimDecisionEnum,
           errors: error.validationErrors,
-          formData: req.session.formData
+          formData: formData
         })
       })
   } else {

--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -62,6 +62,7 @@ module.exports = function (router) {
 
   // POST
   router.post('/claim/:claimId', function (req, res, next) {
+    req.session.formData = parseFormData(req.body)
     return validatePostRequest(req, res, next, function () {
       claimExpenses = getClaimExpenseResponses(req.body)
       return submitClaimDecision(req, res, claimExpenses)

--- a/app/views/claim/view-claim.html
+++ b/app/views/claim/view-claim.html
@@ -21,7 +21,7 @@
       {% if Claim['AssistedDigitalCaseworker'] %}
       <span class="bold-small">Assisted digital - </span>{{ Claim['AssistedDigitalCaseworker'] }}
       {% endif %}
-      <span class="tag {{ Claim['ClaimType'] }}" \>{{ displayHelper.getClaimTypeDisplayName(Claim['ClaimType']) }} {% if Claim['IsAdvanceClaim'] %} - Advance{% endif %}</span>
+      <span class="tag {{ Claim['ClaimType'] }}">{{ displayHelper.getClaimTypeDisplayName(Claim['ClaimType']) }} {% if Claim['IsAdvanceClaim'] %} - Advance{% endif %}</span>
     </div>
 
     <div class="column-quarter">

--- a/app/views/partials/view-claim/add-deduction.html
+++ b/app/views/partials/view-claim/add-deduction.html
@@ -4,9 +4,9 @@
     <tr>
       <td>
         Type: <select id="deductionType" name="deductionType" class="form-control">
-          <option selected>Select</option>
-          <option value="hc3">{{ displayHelper.getDeductionTypeDisplayName('hc3') }}</option>
-          <option value="overpayment">{{ displayHelper.getDeductionTypeDisplayName('overpayment') }}</option>
+          <option {% if not formData.deductionType %}selected{% endif %}>Select</option>
+          <option {% if formData.deductionType == 'hc3' %}selected{% endif %} value="hc3">{{ displayHelper.getDeductionTypeDisplayName('hc3') }}</option>
+          <option {% if formData.deductionType == 'overpayment' %}selected{% endif %} value="overpayment">{{ displayHelper.getDeductionTypeDisplayName('overpayment') }}</option>
         </select>
       </td>
       <td>

--- a/app/views/partials/view-claim/add-deduction.html
+++ b/app/views/partials/view-claim/add-deduction.html
@@ -10,7 +10,7 @@
         </select>
       </td>
       <td>
-        Amount: <input id="deductionAmount" name="deductionAmount" type="text" class="form-control">
+        Amount: <input id="deductionAmount" name="deductionAmount" type="text" class="form-control" value="{{ formData.deductionAmount }}">
       </td>
       <td>
         <input type="submit" formaction="/claim/{{ Claim['ClaimId'] }}/add-deduction" class="button pull-right grey" name="add-deduction" id="add-deduction" value="Submit">

--- a/app/views/partials/view-claim/claim.html
+++ b/app/views/partials/view-claim/claim.html
@@ -18,7 +18,7 @@
         <td><span class="bold">{{ getDisplayFieldName[expense['ExpenseType']] }} </span>
           <br>
           {{ getClaimExpenseDetailFormatted(expense) }}
-          <input id="claim-expense-{{ expense.ClaimExpenseId }}-cost" name="claim-expense-{{ expense.ClaimExpenseId }}-cost" type="hidden" value="{{ expense['Cost'] }}">
+          <input id="claim-expense-{{ expense.ClaimExpenseId }}-cost" name="claim-expense-{{ expense.ClaimExpenseId }}-cost" type="hidden" value="{{ expense['Cost'] or formData.claimExpenseData[expense['ClaimExpenseId']].cost }}">
         </td>
 
         {% if expense.ExpenseType == 'train' and Claim.IsAdvanceClaim %}
@@ -54,16 +54,16 @@
           <select id="claim-expense-{{ expense.ClaimExpenseId }}-status" data-id="{{ expense.ClaimExpenseId }}" name="claim-expense-{{ expense.ClaimExpenseId }}-status"
             class="form-control action-select claim-expense-status">
             <option {% if expense['Status'] == undefined %} selected {% endif %}>Select</option>
-            <option {% if expense['Status'] == claimDecisionEnum.APPROVED %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED }}">Approve</option>
-            <option {% if expense['Status'] == claimDecisionEnum.APPROVED_DIFF_AMOUNT %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED_DIFF_AMOUNT }}" >Approve different amount</option>
-            <option {% if expense['Status'] == claimDecisionEnum.REQUEST_INFORMATION %} selected {% endif %} value="{{ claimDecisionEnum.REQUEST_INFORMATION }}">Request information</option>
+            <option {% if expense['Status'] == claimDecisionEnum.APPROVED or formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.APPROVED %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED }}">Approve</option>
+            <option {% if expense['Status'] == claimDecisionEnum.APPROVED_DIFF_AMOUNT or formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.APPROVED_DIFF_AMOUNT %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED_DIFF_AMOUNT }}" >Approve different amount</option>
+            <option {% if expense['Status'] == claimDecisionEnum.REQUEST_INFORMATION or formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.REQUEST_INFORMATION %} selected {% endif %} value="{{ claimDecisionEnum.REQUEST_INFORMATION }}">Request information</option>
             {% if Claim['IsAdvanceClaim'] %}
-            <option {% if expense['Status'] == claimDecisionEnum.MANUALLY_PROCESSED %} selected {% endif %} value="{{ claimDecisionEnum.MANUALLY_PROCESSED }}">Process manually</option>
+            <option {% if expense['Status'] == claimDecisionEnum.MANUALLY_PROCESSED or formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.MANUALLY_PROCESSED %} selected {% endif %} value="{{ claimDecisionEnum.MANUALLY_PROCESSED }}">Process manually</option>
             {% endif %}
-            <option {% if expense['Status'] == claimDecisionEnum.REJECTED %} selected {% endif %} value="{{ claimDecisionEnum.REJECTED }}">Reject claim</option>
+            <option {% if expense['Status'] == claimDecisionEnum.REJECTED or formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.REJECTED %} selected {% endif %} value="{{ claimDecisionEnum.REJECTED }}">Reject claim</option>
           </select>
           <input id="claim-expense-{{ expense.ClaimExpenseId }}-approvedcost" type="text"
-            name="claim-expense-{{ expense.ClaimExpenseId }}-approvedcost" value="{{ expense['ApprovedCost'] }}"
+            name="claim-expense-{{ expense.ClaimExpenseId }}-approvedcost" value="{{ expense['ApprovedCost'] or formData.claimExpenseData[expense['ClaimExpenseId'].approvedCost] }}"
             class="form-control cost
               {% if expense['Status'] == claimDecisionEnum.APPROVED_DIFF_AMOUNT or expense['Status'] == claimDecisionEnum.MANUALLY_PROCESSED %}
                 visibility-visible

--- a/app/views/partials/view-claim/claim.html
+++ b/app/views/partials/view-claim/claim.html
@@ -18,7 +18,7 @@
         <td><span class="bold">{{ getDisplayFieldName[expense['ExpenseType']] }} </span>
           <br>
           {{ getClaimExpenseDetailFormatted(expense) }}
-          <input id="claim-expense-{{ expense.ClaimExpenseId }}-cost" name="claim-expense-{{ expense.ClaimExpenseId }}-cost" type="hidden" value="{{ expense['Cost'] or formData.claimExpenseData[expense['ClaimExpenseId']].cost }}">
+          <input id="claim-expense-{{ expense.ClaimExpenseId }}-cost" name="claim-expense-{{ expense.ClaimExpenseId }}-cost" type="hidden" value="{{ formData.claimExpenseData[expense['ClaimExpenseId']].cost or expense['Cost'] }}">
         </td>
 
         {% if expense.ExpenseType == 'train' and Claim.IsAdvanceClaim %}
@@ -34,11 +34,11 @@
 
             {% elif expense.DocumentStatus == 'upload-later' %}
               <span class="text-pending">To be uploaded later</span>
-              <a href="/claim/file-upload/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/RECEIPT?eligibilityId={{ Claim['EligibilityId'] }}&claimExpenseId={{ expense.ClaimExpenseId }}&claimDocumentId={{ expense.ClaimDocumentId }}" class="button grey pull-right">Add</a>
+              <input type="submit" formaction="/claim/file-upload-redirect/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/RECEIPT?eligibilityId={{ Claim['EligibilityId'] }}&claimExpenseId={{ expense.ClaimExpenseId }}&claimDocumentId={{ expense.ClaimDocumentId }}" value="Add" class="button grey pull-right">
 
             {% elif expense.DocumentStatus == 'post-later' %}
               <span class="text-pending">To be posted later</span>
-              <a href="/claim/file-upload/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/RECEIPT?eligibilityId={{ Claim['EligibilityId'] }}&claimExpenseId={{ expense.ClaimExpenseId }}&claimDocumentId={{ expense.ClaimDocumentId }}" class="button grey pull-right">Add</a>
+              <input type="submit" formaction="/claim/file-upload-redirect/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/RECEIPT?eligibilityId={{ Claim['EligibilityId'] }}&claimExpenseId={{ expense.ClaimExpenseId }}&claimDocumentId={{ expense.ClaimDocumentId }}" value="Add" class="button grey pull-right">
 
             {% elif expense.ExpenseType == 'train' and Claim.IsAdvanceClaim %}
               <span class="text-pending">Receipt to be uploaded after visit</span>
@@ -54,18 +54,22 @@
           <select id="claim-expense-{{ expense.ClaimExpenseId }}-status" data-id="{{ expense.ClaimExpenseId }}" name="claim-expense-{{ expense.ClaimExpenseId }}-status"
             class="form-control action-select claim-expense-status">
             <option {% if expense['Status'] == undefined %} selected {% endif %}>Select</option>
-            <option {% if expense['Status'] == claimDecisionEnum.APPROVED or formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.APPROVED %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED }}">Approve</option>
-            <option {% if expense['Status'] == claimDecisionEnum.APPROVED_DIFF_AMOUNT or formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.APPROVED_DIFF_AMOUNT %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED_DIFF_AMOUNT }}" >Approve different amount</option>
-            <option {% if expense['Status'] == claimDecisionEnum.REQUEST_INFORMATION or formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.REQUEST_INFORMATION %} selected {% endif %} value="{{ claimDecisionEnum.REQUEST_INFORMATION }}">Request information</option>
+            <option 
+            {% if formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.APPROVED or expense['Status'] == claimDecisionEnum.APPROVED %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED }}">Approve</option>
+            <option {% if formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.APPROVED_DIFF_AMOUNT or expense['Status'] == claimDecisionEnum.APPROVED_DIFF_AMOUNT %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED_DIFF_AMOUNT }}" >Approve different amount</option>
+            <option {% if formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.REQUEST_INFORMATION or expense['Status'] == claimDecisionEnum.REQUEST_INFORMATION %} selected {% endif %} value="{{ claimDecisionEnum.REQUEST_INFORMATION }}">Request information</option>
             {% if Claim['IsAdvanceClaim'] %}
-            <option {% if expense['Status'] == claimDecisionEnum.MANUALLY_PROCESSED or formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.MANUALLY_PROCESSED %} selected {% endif %} value="{{ claimDecisionEnum.MANUALLY_PROCESSED }}">Process manually</option>
+            <option {% if formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.MANUALLY_PROCESSED or expense['Status'] == claimDecisionEnum.MANUALLY_PROCESSED %} selected {% endif %} value="{{ claimDecisionEnum.MANUALLY_PROCESSED }}">Process manually</option>
             {% endif %}
-            <option {% if expense['Status'] == claimDecisionEnum.REJECTED or formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.REJECTED %} selected {% endif %} value="{{ claimDecisionEnum.REJECTED }}">Reject claim</option>
+            <option {% if formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.REJECTED or expense['Status'] == claimDecisionEnum.REJECTED  %} selected {% endif %} value="{{ claimDecisionEnum.REJECTED }}">Reject claim</option>
           </select>
           <input id="claim-expense-{{ expense.ClaimExpenseId }}-approvedcost" type="text"
-            name="claim-expense-{{ expense.ClaimExpenseId }}-approvedcost" value="{{ expense['ApprovedCost'] or formData.claimExpenseData[expense['ClaimExpenseId'].approvedCost] }}"
+            name="claim-expense-{{ expense.ClaimExpenseId }}-approvedcost" value="{{ formData.claimExpenseData[expense['ClaimExpenseId']].approvedCost or expense['ApprovedCost'] }}"
             class="form-control cost
-              {% if expense['Status'] == claimDecisionEnum.APPROVED_DIFF_AMOUNT or expense['Status'] == claimDecisionEnum.MANUALLY_PROCESSED %}
+              {% if (formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.APPROVED_DIFF_AMOUNT 
+                  or formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.MANUALLY_PROCESSED)
+                or (expense['Status'] == claimDecisionEnum.APPROVED_DIFF_AMOUNT 
+                  or expense['Status'] == claimDecisionEnum.MANUALLY_PROCESSED) %}
                 visibility-visible
               {% else %}
                 visibility-hidden

--- a/app/views/partials/view-claim/claim.html
+++ b/app/views/partials/view-claim/claim.html
@@ -54,8 +54,10 @@
           <select id="claim-expense-{{ expense.ClaimExpenseId }}-status" data-id="{{ expense.ClaimExpenseId }}" name="claim-expense-{{ expense.ClaimExpenseId }}-status"
             class="form-control action-select claim-expense-status">
             <option {% if expense['Status'] == undefined %} selected {% endif %}>Select</option>
+            {% if expense['Cost'] > 0 %}
             <option 
             {% if formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.APPROVED or expense['Status'] == claimDecisionEnum.APPROVED %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED }}">Approve</option>
+            {% endif %}
             <option {% if formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.APPROVED_DIFF_AMOUNT or expense['Status'] == claimDecisionEnum.APPROVED_DIFF_AMOUNT %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED_DIFF_AMOUNT }}" >Approve different amount</option>
             <option {% if formData.claimExpenseData[expense['ClaimExpenseId']].status == claimDecisionEnum.REQUEST_INFORMATION or expense['Status'] == claimDecisionEnum.REQUEST_INFORMATION %} selected {% endif %} value="{{ claimDecisionEnum.REQUEST_INFORMATION }}">Request information</option>
             {% if Claim['IsAdvanceClaim'] %}

--- a/app/views/partials/view-claim/prisoner.html
+++ b/app/views/partials/view-claim/prisoner.html
@@ -23,7 +23,7 @@
   <tr {% if errors['nomis-check'][0] %} class="warning"{% endif %}>
     <td>Eligible for visitation?</td>
     <td>
-      {% if Claim['NomisCheck'] != 'APPROVED' %}
+      {% if Claim['NomisCheck'] != 'APPROVED' or formData.nomisCheck == 'APPROVED' %}
       <span class="text-warning">
         {% if displayHelper.getPrisonRegion(Claim['NameOfPrison']) != 'NI' %}
           NOMIS check required
@@ -43,9 +43,9 @@
 
       <select class="form-control action-select" id="nomis-check" name="nomisCheck">
         <option value="">Select</option>
-        <option {% if Claim['NomisCheck'] == 'APPROVED' %} selected {% endif %} value="APPROVED">Approve</option>
-        <option {% if Claim['NomisCheck'] == 'REQUEST-INFORMATION' %} selected {% endif %} value="REQUEST-INFORMATION">Request information</option>
-        <option {% if Claim['NomisCheck'] == 'REJECTED' %} selected {% endif %} value="REJECTED">Reject</option>
+        <option {% if Claim['NomisCheck'] == 'APPROVED' or formData.nomisCheck == 'APPROVED' %} selected {% endif %} value="APPROVED">Approve</option>
+        <option {% if Claim['NomisCheck'] == 'REQUEST-INFORMATION' or formData.nomisCheck == 'REQUEST-INFORMATION' %} selected {% endif %} value="REQUEST-INFORMATION">Request information</option>
+        <option {% if Claim['NomisCheck'] == 'REJECTED' or formData.nomisCheck == 'REJECTED' %} selected {% endif %} value="REJECTED">Reject</option>
       </select>
     </td>
   </tr>

--- a/app/views/partials/view-claim/prisoner.html
+++ b/app/views/partials/view-claim/prisoner.html
@@ -23,7 +23,7 @@
   <tr {% if errors['nomis-check'][0] %} class="warning"{% endif %}>
     <td>Eligible for visitation?</td>
     <td>
-      {% if Claim['NomisCheck'] != 'APPROVED' or formData.nomisCheck == 'APPROVED' %}
+      {% if formData.nomisCheck == 'APPROVED' or Claim['NomisCheck'] != 'APPROVED' %}
       <span class="text-warning">
         {% if displayHelper.getPrisonRegion(Claim['NameOfPrison']) != 'NI' %}
           NOMIS check required
@@ -43,9 +43,9 @@
 
       <select class="form-control action-select" id="nomis-check" name="nomisCheck">
         <option value="">Select</option>
-        <option {% if Claim['NomisCheck'] == 'APPROVED' or formData.nomisCheck == 'APPROVED' %} selected {% endif %} value="APPROVED">Approve</option>
-        <option {% if Claim['NomisCheck'] == 'REQUEST-INFORMATION' or formData.nomisCheck == 'REQUEST-INFORMATION' %} selected {% endif %} value="REQUEST-INFORMATION">Request information</option>
-        <option {% if Claim['NomisCheck'] == 'REJECTED' or formData.nomisCheck == 'REJECTED' %} selected {% endif %} value="REJECTED">Reject</option>
+        <option {% if formData.nomisCheck == 'APPROVED' or Claim['NomisCheck'] == 'APPROVED' %} selected {% endif %} value="APPROVED">Approve</option>
+        <option {% if formData.nomisCheck == 'REQUEST-INFORMATION' or Claim['NomisCheck'] == 'REQUEST-INFORMATION' %} selected {% endif %} value="REQUEST-INFORMATION">Request information</option>
+        <option {% if formData.nomisCheck == 'REJECTED' or Claim['NomisCheck'] == 'REJECTED' %} selected {% endif %} value="REJECTED">Reject</option>
       </select>
     </td>
   </tr>

--- a/app/views/partials/view-claim/visit.html
+++ b/app/views/partials/view-claim/visit.html
@@ -23,9 +23,9 @@
       <td>
         <select class="form-control action-select" id="visit-confirmation-check" name="visitConfirmationCheck">
           <option value="">Select</option>
-          <option {% if Claim['VisitConfirmationCheck'] == 'APPROVED' %} selected {% endif %} value="APPROVED">Approve</option>
-          <option {% if Claim['VisitConfirmationCheck'] == 'REQUEST-INFORMATION' %} selected {% endif %} value="REQUEST-INFORMATION">Request information</option>
-          <option {% if Claim['VisitConfirmationCheck'] == 'REJECTED' %} selected {% endif %} value="REJECTED">Reject</option>
+          <option {% if formData.visitConfirmationCheck == 'APPROVED' or Claim['VisitConfirmationCheck'] == 'APPROVED' %} selected {% endif %} value="APPROVED">Approve</option>
+          <option {% if formData.visitConfirmationCheck == 'REQUEST-INFORMATION' or Claim['VisitConfirmationCheck'] == 'REQUEST-INFORMATION' %} selected {% endif %} value="REQUEST-INFORMATION">Request information</option>
+          <option {% if formData.visitConfirmationCheck == 'REJECTED' or Claim['VisitConfirmationCheck'] == 'REJECTED' %} selected {% endif %} value="REJECTED">Reject</option>
         </select>
       </td>
     </tr>

--- a/app/views/partials/view-claim/visit.html
+++ b/app/views/partials/view-claim/visit.html
@@ -10,11 +10,12 @@
         {% elif Claim.visitConfirmation['DocumentStatus'] == 'upload-later' %}
           <span class="text-pending">To be uploaded later</span>
           <a href="/claim/file-upload/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/VISIT_CONFIRMATION?eligibilityId={{ Claim['EligibilityId'] }}&claimDocumentId={{ Claim.visitConfirmation['ClaimDocumentId'] }}" id="add-visit-confirmation-upload-later" class="button grey pull-right">Add</a>
+          <input type="submit" formaction="/claim/file-upload-redirect/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/VISIT_CONFIRMATION?eligibilityId={{ Claim['EligibilityId'] }}&claimExpenseId={{ expense.ClaimExpenseId }}&claimDocumentId={{ Claim.visitConfirmation['ClaimDocumentId'] }}" value="Add" class="button grey pull-right">
 
         {% elif Claim.visitConfirmation['DocumentStatus'] == 'post-later' %}
           <span class="text-pending">To be posted later</span>
-          <a href="/claim/file-upload/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/VISIT_CONFIRMATION?eligibilityId={{ Claim['EligibilityId'] }}&claimDocumentId={{ Claim.visitConfirmation['ClaimDocumentId'] }}" id="add-visit-confirmation-post-later" class="button grey pull-right">Add</a>
-
+          <input type="submit" formaction="/claim/file-upload-redirect/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/VISIT_CONFIRMATION?eligibilityId={{ Claim['EligibilityId'] }}&claimExpenseId={{ expense.ClaimExpenseId }}&claimDocumentId={{ Claim.visitConfirmation['ClaimDocumentId'] }}" value="Add" class="button grey pull-right">
+          
         {% else %}
           <span class="text-warning">Visit confirmation required</span>
 

--- a/app/views/partials/view-claim/visit.html
+++ b/app/views/partials/view-claim/visit.html
@@ -10,11 +10,11 @@
         {% elif Claim.visitConfirmation['DocumentStatus'] == 'upload-later' %}
           <span class="text-pending">To be uploaded later</span>
           <a href="/claim/file-upload/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/VISIT_CONFIRMATION?eligibilityId={{ Claim['EligibilityId'] }}&claimDocumentId={{ Claim.visitConfirmation['ClaimDocumentId'] }}" id="add-visit-confirmation-upload-later" class="button grey pull-right">Add</a>
-          <input type="submit" formaction="/claim/file-upload-redirect/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/VISIT_CONFIRMATION?eligibilityId={{ Claim['EligibilityId'] }}&claimExpenseId={{ expense.ClaimExpenseId }}&claimDocumentId={{ Claim.visitConfirmation['ClaimDocumentId'] }}" value="Add" class="button grey pull-right">
+          <input type="submit" formaction="/claim/file-upload-redirect/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/VISIT_CONFIRMATION?eligibilityId={{ Claim['EligibilityId'] }}&claimDocumentId={{ Claim.visitConfirmation['ClaimDocumentId'] }}" value="Add" class="button grey pull-right">
 
         {% elif Claim.visitConfirmation['DocumentStatus'] == 'post-later' %}
           <span class="text-pending">To be posted later</span>
-          <input type="submit" formaction="/claim/file-upload-redirect/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/VISIT_CONFIRMATION?eligibilityId={{ Claim['EligibilityId'] }}&claimExpenseId={{ expense.ClaimExpenseId }}&claimDocumentId={{ Claim.visitConfirmation['ClaimDocumentId'] }}" value="Add" class="button grey pull-right">
+          <input type="submit" formaction="/claim/file-upload-redirect/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/VISIT_CONFIRMATION?eligibilityId={{ Claim['EligibilityId'] }}&claimDocumentId={{ Claim.visitConfirmation['ClaimDocumentId'] }}" value="Add" class="button grey pull-right">
           
         {% else %}
           <span class="text-warning">Visit confirmation required</span>

--- a/app/views/partials/view-claim/visitor.html
+++ b/app/views/partials/view-claim/visitor.html
@@ -45,9 +45,9 @@
 
       <select class="form-control action-select" id="dwp-status" name="dwpCheck">
         <option value="">Select</option>
-        <option {% if Claim['DWPCheck'] == 'APPROVED' or formData.dwpCheck == 'APPROVED' %} selected {% endif %} value="APPROVED">Approve</option>
-        <option {% if Claim['DWPCheck'] == 'REQUEST-INFORMATION' or formData.dwpCheck == 'REQUEST-INFORMATION' %} selected {% endif %} value="REQUEST-INFORMATION">Request information</option>
-        <option {% if Claim['DWPCheck'] == 'REJECTED' or formData.dwpCheck == 'REJECTED' %} selected {% endif %} value="REJECTED">Reject</option>
+        <option {% if formData.dwpCheck == 'APPROVED' or Claim['DWPCheck'] == 'APPROVED' %} selected {% endif %} value="APPROVED">Approve</option>
+        <option {% if formData.dwpCheck == 'REQUEST-INFORMATION' or Claim['DWPCheck'] == 'REQUEST-INFORMATION' %} selected {% endif %} value="REQUEST-INFORMATION">Request information</option>
+        <option {% if formData.dwpCheck == 'REJECTED' or Claim['DWPCheck'] == 'REJECTED' %} selected {% endif %} value="REJECTED">Reject</option>
       </select>
 
       <br/>

--- a/app/views/partials/view-claim/visitor.html
+++ b/app/views/partials/view-claim/visitor.html
@@ -59,10 +59,10 @@
           <a href="/claim/{{ Claim['ClaimId'] }}/download?claim-document-id={{ document['ClaimDocumentId'] }}">View evidence</a>
         {% elif document['DocumentStatus'] == 'upload-later' %}
           <span class="text-pending">To be uploaded later</span>
-          <a href="/claim/file-upload/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/{{ Claim['Benefit'] }}?eligibilityId={{ Claim['EligibilityId'] }}&claimDocumentId={{ document['ClaimDocumentId'] }}" id="add-benefit-documentation-upload-later" class="button grey pull-right">Add</a>
+          <input type="submit" formaction="/claim/file-upload-redirect/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/{{ Claim['Benefit'] }}?eligibilityId={{ Claim['EligibilityId'] }}&claimDocumentId={{ document['ClaimDocumentId'] }}" value="Add" class="button grey pull-right">
         {% elif document['DocumentStatus'] == 'post-later' %}
           <span class="text-pending">To be posted later</span>
-          <a href="/claim/file-upload/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/{{ Claim['Benefit'] }}?eligibilityId={{ Claim['EligibilityId'] }}&claimDocumentId={{ document['ClaimDocumentId'] }}" id="add-benefit-documentation-post-later" class="button grey pull-right">Add</a>
+          <input type="submit" formaction="/claim/file-upload-redirect/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/{{ Claim['Benefit'] }}?eligibilityId={{ Claim['EligibilityId'] }}&claimDocumentId={{ document['ClaimDocumentId'] }}" value="Add" class="button grey pull-right">
         {% else %}
           <span class="text-warning">Benefit required</span>
         {% endif %}

--- a/app/views/partials/view-claim/visitor.html
+++ b/app/views/partials/view-claim/visitor.html
@@ -45,9 +45,9 @@
 
       <select class="form-control action-select" id="dwp-status" name="dwpCheck">
         <option value="">Select</option>
-        <option {% if Claim['DWPCheck'] == 'APPROVED' %} selected {% endif %} value="APPROVED">Approve</option>
-        <option {% if Claim['DWPCheck'] == 'REQUEST-INFORMATION' %} selected {% endif %} value="REQUEST-INFORMATION">Request information</option>
-        <option {% if Claim['DWPCheck'] == 'REJECTED' %} selected {% endif %} value="REJECTED">Reject</option>
+        <option {% if Claim['DWPCheck'] == 'APPROVED' or formData.dwpCheck == 'APPROVED' %} selected {% endif %} value="APPROVED">Approve</option>
+        <option {% if Claim['DWPCheck'] == 'REQUEST-INFORMATION' or formData.dwpCheck == 'REQUEST-INFORMATION' %} selected {% endif %} value="REQUEST-INFORMATION">Request information</option>
+        <option {% if Claim['DWPCheck'] == 'REJECTED' or formData.dwpCheck == 'REJECTED' %} selected {% endif %} value="REJECTED">Reject</option>
       </select>
 
       <br/>

--- a/test/unit/routes/claim/test-view-claim.js
+++ b/test/unit/routes/claim/test-view-claim.js
@@ -109,6 +109,9 @@ describe('routes/claim/view-claim', function () {
         'last_name': 'Adams',
         'roles': ['caseworker', 'admin', 'sscl']
       }
+      req.session = {
+        formData: {}
+      }
       next()
     })
     route(app)


### PR DESCRIPTION
Implemented session variable that will track all of the input on the main form of the view-claim page.   User input will not be lost when:
- A user adds or removes a deduction
- User triggers a validation error when submitting a claim decision
- User uploads a document

View-claim page will now use session variables to record values the user has entered.  Also Implemented file-upload-redirect route which simply stores user input in the session and redirects to the upload page.

See #247 and #75 