### PR TITLE
Display full date for payment file downloads

### DIFF
--- a/app/views/download-payment-files.html
+++ b/app/views/download-payment-files.html
@@ -20,7 +20,7 @@
 
       <h3 class="heading-medium">Access Pay file</h3>
       {% if topAccessPayFile %}
-      <a href="/download-payment-files/download?path={{ topAccessPayFile.Filepath }}" class="link">Download file for {{ dateHelper.shortDate(topAccessPayFile.DateCreated) }}</a>
+      <a href="/download-payment-files/download?path={{ topAccessPayFile.Filepath }}" class="link">Download file for {{ dateHelper.shortDateAndTime(topAccessPayFile.DateCreated) }}</a>
       {% endif %}
       <br>
       <br>
@@ -32,7 +32,7 @@
           <div class="panel panel-border-narrow" id="" aria-hidden="false">
             <ul class="list list-bullet">
               {% for previousAccessPayFile in previousAccessPayFiles %}
-              <li><a href="/download-payment-files/download?path={{ previousAccessPayFile.Filepath }}" class="link">Download file for {{ dateHelper.shortDate(previousAccessPayFile.DateCreated) }}</a></li>
+              <li><a href="/download-payment-files/download?path={{ previousAccessPayFile.Filepath }}" class="link">Download file for {{ dateHelper.shortDateAndTime(previousAccessPayFile.DateCreated) }}</a></li>
               {% endfor %}
             </ul>
           </div>


### PR DESCRIPTION
Include time when showing payment file names on download-payment-file page.

See https://github.com/ministryofjustice/apvs-asynchronous-worker/issues/51