### PR TITLE
Removed 'Approve' option for car and train expenses

### DIFF
--- a/app/views/partials/view-claim/claim.html
+++ b/app/views/partials/view-claim/claim.html
@@ -54,7 +54,7 @@
           <select id="claim-expense-{{ expense.ClaimExpenseId }}-status" data-id="{{ expense.ClaimExpenseId }}" name="claim-expense-{{ expense.ClaimExpenseId }}-status"
             class="form-control action-select claim-expense-status">
             <option {% if expense['Status'] == undefined %} selected {% endif %}>Select</option>
-            {% if expense['ExpenseType'] != 'car' and expense['ExpenseType'] != 'train' %}
+            {% if expense['Cost'] > 0 %}
             <option {% if expense['Status'] == claimDecisionEnum.APPROVED %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED }}">Approve</option>
             {% endif %}
             <option {% if expense['Status'] == claimDecisionEnum.APPROVED_DIFF_AMOUNT %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED_DIFF_AMOUNT }}" >Approve different amount</option>

--- a/app/views/partials/view-claim/claim.html
+++ b/app/views/partials/view-claim/claim.html
@@ -54,7 +54,9 @@
           <select id="claim-expense-{{ expense.ClaimExpenseId }}-status" data-id="{{ expense.ClaimExpenseId }}" name="claim-expense-{{ expense.ClaimExpenseId }}-status"
             class="form-control action-select claim-expense-status">
             <option {% if expense['Status'] == undefined %} selected {% endif %}>Select</option>
+            {% if expense['ExpenseType'] != 'car' and expense['ExpenseType'] != 'train' %}
             <option {% if expense['Status'] == claimDecisionEnum.APPROVED %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED }}">Approve</option>
+            {% endif %}
             <option {% if expense['Status'] == claimDecisionEnum.APPROVED_DIFF_AMOUNT %} selected {% endif %} value="{{ claimDecisionEnum.APPROVED_DIFF_AMOUNT }}" >Approve different amount</option>
             <option {% if expense['Status'] == claimDecisionEnum.REQUEST_INFORMATION %} selected {% endif %} value="{{ claimDecisionEnum.REQUEST_INFORMATION }}">Request information</option>
             {% if Claim['IsAdvanceClaim'] %}


### PR DESCRIPTION
Car and train expenses must now have a different amount specified before the user can approve them.

See #265 
