### PR TITLE
chore/fixes-to-view-claim-information-display

### DIFF
--- a/app/views/partials/view-claim/claim.html
+++ b/app/views/partials/view-claim/claim.html
@@ -40,7 +40,7 @@
               <span class="text-pending">To be posted later</span>
               <a href="/claim/file-upload/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/RECEIPT?eligibilityId={{ Claim['EligibilityId'] }}&claimExpenseId={{ expense.ClaimExpenseId }}&claimDocumentId={{ expense.ClaimDocumentId }}" class="button grey pull-right">Add</a>
 
-            {% elif expense.ExpenseType == 'train' and Claim.IsAdvanceClaim %}
+            {% elif Claim.IsAdvanceClaim %}
               <span class="text-pending">Receipt to be uploaded after visit</span>
 
             {% else %}

--- a/app/views/partials/view-claim/visit.html
+++ b/app/views/partials/view-claim/visit.html
@@ -15,6 +15,8 @@
           <span class="text-pending">To be posted later</span>
           <a href="/claim/file-upload/{{ Claim['Reference'] }}/{{ Claim['ClaimId'] }}/VISIT_CONFIRMATION?eligibilityId={{ Claim['EligibilityId'] }}&claimDocumentId={{ Claim.visitConfirmation['ClaimDocumentId'] }}" id="add-visit-confirmation-post-later" class="button grey pull-right">Add</a>
 
+        {% elif Claim.IsAdvanceClaim %}
+          <span class="text-pending">Visit confirmation to be uploaded after visit</span>
         {% else %}
           <span class="text-warning">Visit confirmation required</span>
 

--- a/app/views/partials/view-claim/visitor.html
+++ b/app/views/partials/view-claim/visitor.html
@@ -20,7 +20,8 @@
     <td>{{ Claim['HouseNumberAndStreet'] }}<br>
       {{ Claim['Town'] }}<br>
       {{ Claim['County'] }}<br>
-      {{ Claim['PostCode'] }}</td>
+      {{ Claim['PostCode'] }}<br>
+      {{ Claim['Country'] }}</td>
   </tr>
 
   <tr>


### PR DESCRIPTION
View claim now showing country and advance claims display to be uploaded after visit
 
* Country now shown
* Visit confirmation and receipts now say to be uploaded after visit on all advance claims rather than being required
