### PR TITLE
Updated table function to look for isenabled

### DIFF
--- a/seeds/add-get-claim-documents-historic-claim.js
+++ b/seeds/add-get-claim-documents-historic-claim.js
@@ -24,6 +24,7 @@ exports.seed = function (knex, Promise) {
               WHERE
                 ClaimDocument.Reference = @reference AND
                 ClaimDocument.EligibilityId = @eligibilityId AND
+                ClaimDocument.IsEnabled = 'true' AND
                 (ClaimDocument.ClaimId = @claimId OR
                 ClaimDocument.ClaimId IS NULL)
             )


### PR DESCRIPTION
Function would previously bring back all docs and benefit documents could not handle this when they were single document benefits
Issue on external: https://github.com/ministryofjustice/apvs-external-web/issues/493