### PR TITLE
Chore/increase code coverage routes

### DIFF
--- a/test/helpers/routes/route-helper.js
+++ b/test/helpers/routes/route-helper.js
@@ -9,9 +9,18 @@ const VIEWS_DIRECTORY = '../../../app/views'
 module.exports.buildApp = function (route) {
   var app = express()
   app.use(bodyParser.json())
-  app.use(bodyParser.urlencoded({ extended: false }))
   app.use(expressSanitized())
   app.use(cookieParser())
+
+  app.use(function (req, res, next) {
+    req.user = {
+      email: 'test@test.com',
+      'first_name': 'Andrew',
+      'last_name': 'Adams',
+      'roles': ['caseworker', 'admin', 'sscl']
+    }
+    next()
+  })
 
   route(app)
   mockViewEngine(app, VIEWS_DIRECTORY)

--- a/test/helpers/routes/route-helper.js
+++ b/test/helpers/routes/route-helper.js
@@ -1,0 +1,29 @@
+const mockViewEngine = require('../../unit/routes/mock-view-engine')
+const express = require('express')
+const bodyParser = require('body-parser')
+const expressSanitized = require('express-sanitized')
+const cookieParser = require('cookie-parser')
+
+const VIEWS_DIRECTORY = '../../../app/views'
+
+module.exports.buildApp = function (route) {
+  var app = express()
+  app.use(bodyParser.json())
+  app.use(bodyParser.urlencoded({ extended: false }))
+  app.use(expressSanitized())
+  app.use(cookieParser())
+
+  route(app)
+  mockViewEngine(app, VIEWS_DIRECTORY)
+
+  app.use(function (req, res, next) {
+    next(new Error())
+  })
+
+  app.use(function (err, req, res, next) {
+    if (err) {
+      res.status(500).render('includes/error')
+    }
+  })
+  return app
+}

--- a/test/unit/routes/claim/test-file-upload.js
+++ b/test/unit/routes/claim/test-file-upload.js
@@ -1,9 +1,7 @@
-const mockViewEngine = require('../mock-view-engine')
+const routeHelper = require('../../../helpers/routes/route-helper')
 const supertest = require('supertest')
 const proxyquire = require('proxyquire')
-const express = require('express')
 const sinon = require('sinon')
-const bodyParser = require('body-parser')
 const ValidationError = require('../../../../app/services/errors/validation-error')
 require('sinon-bluebird')
 
@@ -40,24 +38,8 @@ describe('routes/claim/file-upload', function () {
       '../../services/generate-csrf-token': generateCSRFTokenStub,
       'csurf': function () { return function () { } }
     })
-    app = express()
-    app.use(bodyParser.json())
-    mockViewEngine(app, '../../../app/views')
-    app.use(function (req, res, next) {
-      req.user = {
-        'email': 'test@test.com',
-        'first_name': 'Andrew',
-        'last_name': 'Adams',
-        'roles': ['caseworker', 'admin', 'sscl']
-      }
-      next()
-    })
+    app = routeHelper.buildApp(route)
     route(app)
-    app.use(function (err, req, res, next) {
-      if (err) {
-        res.status(500).render('includes/error')
-      }
-    })
   })
 
   describe(`GET ${BASEROUTE}`, function () {

--- a/test/unit/routes/claim/test-view-claim.js
+++ b/test/unit/routes/claim/test-view-claim.js
@@ -1,8 +1,7 @@
+const routeHelper = require('../../../helpers/routes/route-helper')
 const supertest = require('supertest')
 const expect = require('chai').expect
 const proxyquire = require('proxyquire')
-const express = require('express')
-const mockViewEngine = require('../mock-view-engine')
 const sinon = require('sinon')
 require('sinon-bluebird')
 
@@ -25,7 +24,6 @@ var stubRequestNewBankDetails
 var stubUpdateEligibilityTrustedStatus
 var ValidationError = require('../../../../app/services/errors/validation-error')
 var deductionTypeEnum = require('../../../../app/constants/deduction-type-enum')
-var bodyParser = require('body-parser')
 const VALID_CLAIMEXPENSE_DATA = [{claimExpenseId: '1', approvedCost: '20.00', cost: '20.00', status: 'APPROVED'}]
 const VALID_DATA_APPROVE = {
   'decision': 'APPROVED',
@@ -99,27 +97,8 @@ describe('routes/claim/view-claim', function () {
       '../../services/data/request-new-bank-details': stubRequestNewBankDetails,
       '../../services/data/update-eligibility-trusted-status': stubUpdateEligibilityTrustedStatus
     })
-    app = express()
-    app.use(bodyParser.json())
-    mockViewEngine(app, '../../../app/views')
-    app.use(function (req, res, next) {
-      req.user = {
-        'email': 'test@test.com',
-        'first_name': 'Andrew',
-        'last_name': 'Adams',
-        'roles': ['caseworker', 'admin', 'sscl']
-      }
-      next()
-    })
+    app = routeHelper.buildApp(route)
     route(app)
-    app.use(function (req, res, next) {
-      next(new Error())
-    })
-    app.use(function (err, req, res, next) {
-      if (err) {
-        res.status(500).render('includes/error')
-      }
-    })
   })
 
   describe('GET /claim/:claimId', function () {

--- a/test/unit/routes/test-advanced-search.js
+++ b/test/unit/routes/test-advanced-search.js
@@ -164,9 +164,18 @@ describe('routes/index', function () {
   })
 
   describe('GET /advanced-search', function () {
-    it('should respond with a 200', function () {
+    it('should respond with a 200 for no query string', function () {
       return supertest(app)
         .get('/advanced-search')
+        .expect(200)
+        .expect(function () {
+          expect(isCaseworkerStub.calledOnce).to.be.true
+        })
+    })
+
+    it('should respond with a 200 with query string', function () {
+      return supertest(app)
+        .get('/advanced-search?Reference=V123456')
         .expect(200)
         .expect(function () {
           expect(isCaseworkerStub.calledOnce).to.be.true
@@ -225,6 +234,13 @@ describe('routes/index', function () {
         .expect(function (response) {
           expect(getClaimListForAdvancedSearch.calledWith(sinon.match(processedSearchCriteria), start, length), 'expected data method to be called with processed search criteria').to.be.true
         })
+    })
+
+    it('should respond with a 500 promise rejects', function () {
+      getClaimListForAdvancedSearch.rejects()
+      return supertest(app)
+        .get('/advanced-search-results')
+        .expect(500)
     })
   })
 

--- a/test/unit/routes/test-config.js
+++ b/test/unit/routes/test-config.js
@@ -29,12 +29,6 @@ describe('routes/config', function () {
     })
 
     app = routeHelper.buildApp(route)
-    app.use(function (req, res, next) {
-      req.user = {
-        email: 'test@test.com'
-      }
-      next()
-    })
     route(app)
   })
 

--- a/test/unit/routes/test-config.js
+++ b/test/unit/routes/test-config.js
@@ -17,7 +17,7 @@ describe('routes/config', function () {
 
   beforeEach(function () {
     isAdmin = sinon.stub()
-    getAutoApprovalConfigStub = sinon.stub().resolves({ RulesDisabled: '' })
+    getAutoApprovalConfigStub = sinon.stub().resolves({ RulesDisabled: 'Test' })
     updateAutoApprovalConfigStub = sinon.stub().resolves()
     AutoApprovalConfigStub = sinon.stub().returns({})
 
@@ -33,7 +33,7 @@ describe('routes/config', function () {
   })
 
   describe('GET /config', function () {
-    it('should respond with a 200', function () {
+    it('should respond with a 200 for rules disabled defined', function () {
       return supertest(app)
         .get('/config')
         .expect(200)
@@ -41,6 +41,24 @@ describe('routes/config', function () {
           expect(isAdmin.calledOnce).to.be.true
           expect(getAutoApprovalConfigStub.calledOnce).to.be.true
         })
+    })
+
+    it('should respond with a 200 for rules disabled not defined', function () {
+      getAutoApprovalConfigStub.resolves({})
+      return supertest(app)
+        .get('/config')
+        .expect(200)
+        .expect(function () {
+          expect(isAdmin.calledOnce).to.be.true
+          expect(getAutoApprovalConfigStub.calledOnce).to.be.true
+        })
+    })
+
+    it('should respond with a 500 promise rejects', function () {
+      getAutoApprovalConfigStub.rejects()
+      return supertest(app)
+        .get('/config')
+        .expect(500)
     })
   })
 
@@ -61,6 +79,13 @@ describe('routes/config', function () {
       return supertest(app)
         .post('/config')
         .expect(400)
+    })
+
+    it('should respond with a 500 if error other than validation thrown', function () {
+      updateAutoApprovalConfigStub.throws(new Error())
+      return supertest(app)
+        .post('/config')
+        .expect(500)
     })
 
     it('should construct empty rulesDisabled array when all rules are enabled', function () {
@@ -106,6 +131,13 @@ describe('routes/config', function () {
             undefined,
             EXPECTED_RULES_DISABLED)
         })
+    })
+
+    it('should respond with a 500 promise rejects and update fails', function () {
+      updateAutoApprovalConfigStub.rejects()
+      return supertest(app)
+        .post('/config')
+        .expect(500)
     })
   })
 })

--- a/test/unit/routes/test-config.js
+++ b/test/unit/routes/test-config.js
@@ -1,10 +1,7 @@
+const routeHelper = require('../../helpers/routes/route-helper')
 const supertest = require('supertest')
 const expect = require('chai').expect
 const proxyquire = require('proxyquire')
-const express = require('express')
-const mockViewEngine = require('./mock-view-engine')
-const bodyParser = require('body-parser')
-const expressSanitizer = require('express-sanitized')
 const sinon = require('sinon')
 require('sinon-bluebird')
 const ValidationError = require('../../../app/services/errors/validation-error')
@@ -31,10 +28,7 @@ describe('routes/config', function () {
       '../services/domain/auto-approval-config': AutoApprovalConfigStub
     })
 
-    app = express()
-    app.use(bodyParser.json())
-    app.use(expressSanitizer())
-    mockViewEngine(app, '../../../app/views')
+    app = routeHelper.buildApp(route)
     app.use(function (req, res, next) {
       req.user = {
         email: 'test@test.com'

--- a/test/unit/routes/test-download-payment-files.js
+++ b/test/unit/routes/test-download-payment-files.js
@@ -8,8 +8,11 @@ require('sinon-bluebird')
 var isSscl
 var getDirectPaymentFiles
 
-const DIRECT_PAYMENT_FILES = {
-  accessPayFiles: [{FilePath: 'accessPayFile1'}, {FilePath: 'accessPayFile2'}],
+const ACCESS_PAYMENT_FILES = {
+  accessPayFiles: [{FilePath: 'accessPayFile1'}, {FilePath: 'accessPayFile2'}]
+}
+
+const ADI_JOURNAL_FILES = {
   adiJournalFiles: [{FilePath: 'adiJournalFile1'}, {FilePath: 'adiJournalFile2'}]
 }
 
@@ -30,7 +33,7 @@ describe('routes/download-payment-files', function () {
 
   describe('GET /download-payment-files', function () {
     it('should respond with a 200', function () {
-      getDirectPaymentFiles.resolves(DIRECT_PAYMENT_FILES)
+      getDirectPaymentFiles.resolves()
       return supertest(app)
         .get('/download-payment-files')
         .expect(200)
@@ -40,14 +43,23 @@ describe('routes/download-payment-files', function () {
         })
     })
 
-    it('should set top and previous payment files', function () {
-      getDirectPaymentFiles.resolves(DIRECT_PAYMENT_FILES)
+    it('should set top and previous access payment files', function () {
+      getDirectPaymentFiles.resolves(ACCESS_PAYMENT_FILES)
       return supertest(app)
         .get('/download-payment-files')
         .expect(200)
         .expect(function (response) {
           expect(response.text).to.contain('"topAccessPayFile":{')
           expect(response.text).to.contain('"previousAccessPayFiles":[')
+        })
+    })
+
+    it('should set top and previous adi journal files', function () {
+      getDirectPaymentFiles.resolves(ADI_JOURNAL_FILES)
+      return supertest(app)
+        .get('/download-payment-files')
+        .expect(200)
+        .expect(function (response) {
           expect(response.text).to.contain('"topAdiJournalFile":{')
           expect(response.text).to.contain('"previousAdiJournalFiles":[')
         })

--- a/test/unit/routes/test-index.js
+++ b/test/unit/routes/test-index.js
@@ -1,8 +1,7 @@
+const routeHelper = require('../../helpers/routes/route-helper')
 const supertest = require('supertest')
 const expect = require('chai').expect
 const proxyquire = require('proxyquire')
-const express = require('express')
-const mockViewEngine = require('./mock-view-engine')
 const claimStatusEnum = require('../../../app/constants/claim-status-enum')
 const sinon = require('sinon')
 require('sinon-bluebird')
@@ -39,9 +38,7 @@ describe('routes/index', function () {
       '../views/helpers/display-helper': displayHelperStub
     })
 
-    app = express()
-    mockViewEngine(app, '../../../app/views')
-    route(app)
+    app = routeHelper.buildApp(route)
   })
 
   describe('GET /', function () {

--- a/test/unit/routes/test-index.js
+++ b/test/unit/routes/test-index.js
@@ -99,5 +99,12 @@ describe('routes/index', function () {
           expect(getClaimsListAndCount.calledWith(claimStatusEnum.UPDATED.value, true, 0, 10)).to.be.true
         })
     })
+
+    it('should respond with a 500 promise rejects', function () {
+      getClaimsListAndCount.rejects()
+      return supertest(app)
+        .get('/claims/TEST?draw=1&start=0&length=10')
+        .expect(500)
+    })
   })
 })

--- a/test/unit/routes/test-search.js
+++ b/test/unit/routes/test-search.js
@@ -1,8 +1,7 @@
+const routeHelper = require('../../helpers/routes/route-helper')
 const supertest = require('supertest')
 const expect = require('chai').expect
 const proxyquire = require('proxyquire')
-const express = require('express')
-const mockViewEngine = require('./mock-view-engine')
 const sinon = require('sinon')
 require('sinon-bluebird')
 
@@ -38,9 +37,7 @@ describe('routes/index', function () {
       '../views/helpers/display-helper': displayHelperStub
     })
 
-    app = express()
-    mockViewEngine(app, '../../../app/views')
-    route(app)
+    app = routeHelper.buildApp(route)
   })
 
   describe('GET /search', function () {

--- a/test/unit/routes/test-search.js
+++ b/test/unit/routes/test-search.js
@@ -79,5 +79,13 @@ describe('routes/index', function () {
           expect(getClaimListForSearch.notCalled).to.be.true
         })
     })
+
+    it('should respond with a 500 promise rejects', function () {
+      var searchQuery = 'Joe Bloggs'
+      getClaimListForSearch.rejects()
+      return supertest(app)
+        .get(`/search-results?q=${searchQuery}&draw=${draw}&start=${start}&length=${length}`)
+        .expect(500)
+    })
   })
 })


### PR DESCRIPTION
Introduced routeHelper to tests as used in external - also improved test coverage on route files
 
* Added route helper
* index route to 100% test coverage
* Download payment files to 100% test coverage
* Search to 100% test coverage
* Config test coverage increased
* Advance Search test coverage increased - a large case statement left as requires lots of code to cover in test for little benefit

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards