### PR TITLE
Feature/apvs 1269/visit confirmation advance claims

### DIFF
--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -169,7 +169,8 @@ function submitClaimDecision (req, res, claimExpenses) {
     req.body.nomisCheck,
     req.body.dwpCheck,
     req.body.visitConfirmationCheck,
-    claimExpenses
+    claimExpenses,
+    req.body.isAdvanceClaim
   )
   return SubmitClaimResponse(req.params.claimId, claimDecision)
     .then(function () {

--- a/app/services/data/close-advance-claim.js
+++ b/app/services/data/close-advance-claim.js
@@ -8,7 +8,7 @@ module.exports = function (claimId, note) {
   return knex('Claim')
     .where('ClaimId', claimId)
     .returning(['Reference', 'EligibilityId'])
-    .update({Status: claimStatusEnum.APPROVED_ADVANCE_CLOSED.value, 'LastUpdated': dateFormatter.now().toDate()})
+    .update({'Status': claimStatusEnum.APPROVED_ADVANCE_CLOSED.value, 'VisitConfirmationCheck': claimStatusEnum.APPROVED.value, 'LastUpdated': dateFormatter.now().toDate()})
       .then(function (updatedClaimData) {
         var claim = updatedClaimData[0]
         return insertClaimEvent(claim.Reference, claim.EligibilityId, claimId, 'CLOSE-ADVANCE-CLAIM', null, note, null, true)

--- a/app/services/data/close-advance-claim.js
+++ b/app/services/data/close-advance-claim.js
@@ -8,7 +8,7 @@ module.exports = function (claimId, note) {
   return knex('Claim')
     .where('ClaimId', claimId)
     .returning(['Reference', 'EligibilityId'])
-    .update({'Status': claimStatusEnum.APPROVED_ADVANCE_CLOSED.value, 'VisitConfirmationCheck': claimStatusEnum.APPROVED.value, 'LastUpdated': dateFormatter.now().toDate()})
+    .update({'Status': claimStatusEnum.APPROVED_ADVANCE_CLOSED.value, 'LastUpdated': dateFormatter.now().toDate()})
       .then(function (updatedClaimData) {
         var claim = updatedClaimData[0]
         return insertClaimEvent(claim.Reference, claim.EligibilityId, claimId, 'CLOSE-ADVANCE-CLAIM', null, note, null, true)

--- a/app/services/domain/claim-decision.js
+++ b/app/services/domain/claim-decision.js
@@ -16,7 +16,8 @@ class ClaimDecision {
                nomisCheck,
                dwpCheck,
                visitConfirmationCheck,
-               claimExpenseResponses) {
+               claimExpenseResponses,
+               isAdvanceClaim) {
     this.caseworker = caseworker
     this.assistedDigitalCaseworker = assistedDigitalCaseworker
 
@@ -44,6 +45,7 @@ class ClaimDecision {
         expense.approvedCost = null
       }
     })
+    this.isAdvanceClaim = isAdvanceClaim
     this.IsValid()
   }
 
@@ -92,8 +94,10 @@ class ClaimDecision {
     FieldValidator(this.dwpCheck, 'dwp-check', errors)
       .isRequired(ERROR_MESSAGES.getBenefitCheckRequired)
 
-    FieldValidator(this.visitConfirmationCheck, 'visit-confirmation-check', errors)
-      .isRequired(ERROR_MESSAGES.getVisitConfirmationRequired)
+    if (!this.isAdvanceClaim) {
+      FieldValidator(this.visitConfirmationCheck, 'visit-confirmation-check', errors)
+        .isRequired(ERROR_MESSAGES.getVisitConfirmationRequired)
+    }
 
     var validationErrors = errors.get()
 

--- a/app/views/helpers/display-helper.js
+++ b/app/views/helpers/display-helper.js
@@ -6,6 +6,7 @@ const deductionTypeEnum = require('../../constants/deduction-type-enum')
 const paymentMethodEnum = require('../../constants/payment-method-enum')
 const rulesEnum = require('../../constants/region-rules-enum')
 const enumHelper = require('../../constants/helpers/enum-helper')
+const moment = require('moment')
 
 module.exports.getBenefitDisplayName = function (value) {
   var element = enumHelper.getKeyByValue(benefitsEnum, value)
@@ -47,9 +48,18 @@ module.exports.getDeductionTypeDisplayName = function (value) {
   return element.displayName
 }
 
-module.exports.getClaimStatusClosed = function (claimStatusValue) {
-  var element = enumHelper.getKeyByValue(claimStatusEnum, claimStatusValue)
-  return element.closed
+module.exports.getClaimStatusClosed = function (claimStatusValue, isAdvanceClaim, dateOfJourney) {
+  if (isAdvanceClaim && claimStatusValue === claimStatusEnum.UPDATED.value) {
+    var currentDate = moment()
+    if (moment(dateOfJourney).isSameOrBefore(currentDate, 'day')) {
+      return true
+    } else {
+      return false
+    }
+  } else {
+    var element = enumHelper.getKeyByValue(claimStatusEnum, claimStatusValue)
+    return element.closed
+  }
 }
 
 module.exports.getPaymentMethodDisplayName = function (paymentMethodValue) {

--- a/app/views/partials/view-claim/close-advance-claim.html
+++ b/app/views/partials/view-claim/close-advance-claim.html
@@ -1,5 +1,5 @@
-{% if displayHelper.getClaimStatusClosed(Claim['Status']) %}
-  <div class="panel js-hidden" id="close-advanced-claim-input">  
+{% if displayHelper.getClaimStatusClosed(Claim['Status'], Claim['IsAdvanceClaim'], Claim['DateOfJourney']) %}
+  <div class="panel js-hidden" id="close-advanced-claim-input">
     <div class="form-group">
       <label class="form-label-bold" for="close-advance-claim-reason">Additional information (optional)</label>
       <textarea id="close-advance-claim-reason" class="form-control" name="close-advance-claim-reason"></textarea>

--- a/app/views/partials/view-claim/closed-claim-actions.html
+++ b/app/views/partials/view-claim/closed-claim-actions.html
@@ -7,7 +7,7 @@
         <span>Manage Overpayment</span>
       </label>
 
-      {% if Claim['IsAdvanceClaim'] == true %}
+      {% if Claim['IsAdvanceClaim'] == true and Claim['Status'] != 'APPROVED-ADVANCE-CLOSED' %}
       <label for="close-toggle" class="block-label inline" data-target="close-advanced-claim-input">
         <input type="radio" name="closed-claim-action" value="CLOSE-ADVANCE-CLAIM" id="close-toggle">
         <span>Close Advance Claim</span>

--- a/app/views/partials/view-claim/closed-claim-actions.html
+++ b/app/views/partials/view-claim/closed-claim-actions.html
@@ -1,5 +1,5 @@
-{% if displayHelper.getClaimStatusClosed(Claim['Status']) %}
-  <!-- Radio Buttons -->    
+{% if displayHelper.getClaimStatusClosed(Claim['Status'], Claim['IsAdvanceClaim'], Claim['DateOfJourney']) %}
+  <!-- Radio Buttons -->
   <form>
     <fieldset id="closedClaimActions">
       <label for="overpayment-toggle" class="block-label inline" data-target="overpayment-input">

--- a/app/views/partials/view-claim/decision.html
+++ b/app/views/partials/view-claim/decision.html
@@ -1,4 +1,4 @@
-{% if not displayHelper.getClaimStatusClosed(Claim['Status']) %}
+{% if not displayHelper.getClaimStatusClosed(Claim['Status'], Claim['IsAdvanceClaim'], Claim['DateOfJourney']) %}
 <div id="decision" class="form-group {% if errors['decision'][0] %} error {% endif %}">
   <fieldset id='reason' >
     <label for="approve" class="block-label inline" data-target="accept-input">

--- a/app/views/partials/view-claim/manage-overpayments.html
+++ b/app/views/partials/view-claim/manage-overpayments.html
@@ -1,6 +1,6 @@
-{% if displayHelper.getClaimStatusClosed(Claim['Status']) %}
+{% if displayHelper.getClaimStatusClosed(Claim['Status'], Claim['IsAdvanceClaim'], Claim['DateOfJourney']) %}
 <!-- Manage Overpayments -->
-  <div class="panel js-hidden" id="overpayment-input">    
+  <div class="panel js-hidden" id="overpayment-input">
     {% if Claim['IsOverpaid'] != true %}
     <div class="form-group" id='overpayment-amount-group' >
       <label class="form-label-bold" for="overpayment-amount">Amount</label>

--- a/app/views/partials/view-claim/request-new-payment-details.html
+++ b/app/views/partials/view-claim/request-new-payment-details.html
@@ -1,4 +1,4 @@
-{% if displayHelper.getClaimStatusClosed(Claim['Status']) %}
+{% if displayHelper.getClaimStatusClosed(Claim['Status'], Claim['IsAdvanceClaim'], Claim['DateOfJourney']) %}
 <!-- Request New Payment Details -->
   <div class="panel js-hidden" id="request-new-payment-details-input">
     {% if Claim[Status] == 'REJECTED' %}
@@ -11,7 +11,7 @@
     </div>
     <input type="submit" class="button grey" name="request-new-payment-details" id="request-new-payment-details" value="Submit">
 
-    {% endif %}     
+    {% endif %}
   </div>
 <!-- Request New Payment Details -->
 {% endif %}

--- a/app/views/partials/view-claim/visit.html
+++ b/app/views/partials/view-claim/visit.html
@@ -23,12 +23,16 @@
         {% endif %}
       </td>
       <td>
+      {% if not Claim.IsAdvanceClaim %}
         <select class="form-control action-select" id="visit-confirmation-check" name="visitConfirmationCheck">
           <option value="">Select</option>
           <option {% if Claim['VisitConfirmationCheck'] == 'APPROVED' %} selected {% endif %} value="APPROVED">Approve</option>
           <option {% if Claim['VisitConfirmationCheck'] == 'REQUEST-INFORMATION' %} selected {% endif %} value="REQUEST-INFORMATION">Request information</option>
           <option {% if Claim['VisitConfirmationCheck'] == 'REJECTED' %} selected {% endif %} value="REJECTED">Reject</option>
         </select>
+      {% else %}
+        <input type="hidden" name="isAdvanceClaim" value="{{ Claim.IsAdvanceClaim }}">
+      {% endif %}
       </td>
     </tr>
   </tbody>

--- a/test/integration/services/data/test-close-advance-claim.js
+++ b/test/integration/services/data/test-close-advance-claim.js
@@ -29,6 +29,7 @@ describe('services/data/close-advance-claim', function () {
           return knex('Claim').first().where('ClaimId', claimId)
             .then(function (claim) {
               expect(claim.Status).to.equal(claimStatusEnum.APPROVED_ADVANCE_CLOSED.value)
+              expect(claim.VisitConfirmationCheck).to.equal(claimStatusEnum.APPROVED.value)
               expect(claim.lastUpdated).to.not.equal(previousLastUpdated)
               return knex('ClaimEvent').first().where('ClaimId', claimId).orderBy('DateAdded', 'desc')
             })

--- a/test/integration/services/data/test-close-advance-claim.js
+++ b/test/integration/services/data/test-close-advance-claim.js
@@ -29,7 +29,6 @@ describe('services/data/close-advance-claim', function () {
           return knex('Claim').first().where('ClaimId', claimId)
             .then(function (claim) {
               expect(claim.Status).to.equal(claimStatusEnum.APPROVED_ADVANCE_CLOSED.value)
-              expect(claim.VisitConfirmationCheck).to.equal(claimStatusEnum.APPROVED.value)
               expect(claim.lastUpdated).to.not.equal(previousLastUpdated)
               return knex('ClaimEvent').first().where('ClaimId', claimId).orderBy('DateAdded', 'desc')
             })

--- a/test/unit/services/domain/test-claim-decision.js
+++ b/test/unit/services/domain/test-claim-decision.js
@@ -16,18 +16,28 @@ describe('services/domain/claim-decision', function () {
   const VALID_NOMIS_CHECK = 'APPROVED'
   const VALID_DWP_CHECK = 'APPROVED'
   const VALID_VISIT_CONFIRMATION_CHECK = 'APPROVED'
+  const NOT_ADVANCE_CLAIM = false
+  const ADVANCE_CLAIM = true
 
   it('should construct a domain object given valid input', function () {
-    claimDecision = new ClaimDecision(VALID_CASEWORKER, VALID_ASSISTED_DIGITAL_CASEWORKER, VALID_DECISION_REJECTED, '', '', VALID_NOTE_REJECTION, VALID_NOMIS_CHECK, VALID_DWP_CHECK, VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES)
+    claimDecision = new ClaimDecision(VALID_CASEWORKER, VALID_ASSISTED_DIGITAL_CASEWORKER, VALID_DECISION_REJECTED, '', '', VALID_NOTE_REJECTION, VALID_NOMIS_CHECK, VALID_DWP_CHECK, VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES, NOT_ADVANCE_CLAIM)
     expect(claimDecision.decision).to.equal(VALID_DECISION_REJECTED)
     expect(claimDecision.nomisCheck).to.equal(VALID_NOMIS_CHECK)
     expect(claimDecision.dwpCheck).to.equal(VALID_DWP_CHECK)
     expect(claimDecision.visitConfirmationCheck).to.equal(VALID_VISIT_CONFIRMATION_CHECK)
   })
 
+  it('should construct a domain object given valid input but no visit confirmation as advance claim', function () {
+    claimDecision = new ClaimDecision(VALID_CASEWORKER, VALID_ASSISTED_DIGITAL_CASEWORKER, VALID_DECISION_REJECTED, '', '', VALID_NOTE_REJECTION, VALID_NOMIS_CHECK, VALID_DWP_CHECK, '', VALID_CLAIMEXPENSES, ADVANCE_CLAIM)
+    expect(claimDecision.decision).to.equal(VALID_DECISION_REJECTED)
+    expect(claimDecision.nomisCheck).to.equal(VALID_NOMIS_CHECK)
+    expect(claimDecision.dwpCheck).to.equal(VALID_DWP_CHECK)
+    expect(claimDecision.visitConfirmationCheck).to.equal('')
+  })
+
   it('should return isRequired error for decision given empty strings', function () {
     try {
-      claimDecision = new ClaimDecision(VALID_CASEWORKER, VALID_ASSISTED_DIGITAL_CASEWORKER, '', '', '', VALID_NOTE_REJECTION, VALID_NOMIS_CHECK, VALID_DWP_CHECK, VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES)
+      claimDecision = new ClaimDecision(VALID_CASEWORKER, VALID_ASSISTED_DIGITAL_CASEWORKER, '', '', '', VALID_NOTE_REJECTION, VALID_NOMIS_CHECK, VALID_DWP_CHECK, VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES, NOT_ADVANCE_CLAIM)
       expect(false, 'should have thrown validation error').to.be.true
     } catch (e) {
       expect(e).to.be.instanceof(ValidationError)
@@ -37,7 +47,7 @@ describe('services/domain/claim-decision', function () {
 
   it('should return isRequired error for note given on reject', function () {
     try {
-      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', VALID_DECISION_REJECTED, '', '', '', VALID_NOMIS_CHECK, '', VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES)
+      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', VALID_DECISION_REJECTED, '', '', '', VALID_NOMIS_CHECK, '', VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES, NOT_ADVANCE_CLAIM)
     } catch (e) {
       expect(e).to.be.instanceof(ValidationError)
       expect(e.validationErrors['additional-info-reject'][0]).to.equal('More information needed')
@@ -46,7 +56,7 @@ describe('services/domain/claim-decision', function () {
 
   it('should return isRequired error for note given on request information', function () {
     try {
-      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', VALID_DECISION_REQUESTED, '', '', '', VALID_NOMIS_CHECK, '', VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES)
+      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', VALID_DECISION_REQUESTED, '', '', '', VALID_NOMIS_CHECK, '', VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES, NOT_ADVANCE_CLAIM)
     } catch (e) {
       expect(e).to.be.instanceof(ValidationError)
       expect(e.validationErrors['additional-info-request'][0]).to.equal('More information needed')
@@ -55,7 +65,7 @@ describe('services/domain/claim-decision', function () {
 
   it('should return isRequired error for nomis-check given empty strings', function () {
     try {
-      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', '', '', '', '', '', '', VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES)
+      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', '', '', '', '', '', '', VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES, NOT_ADVANCE_CLAIM)
       expect(false, 'should have thrown validation error').to.be.true
     } catch (e) {
       expect(e).to.be.instanceof(ValidationError)
@@ -65,7 +75,7 @@ describe('services/domain/claim-decision', function () {
 
   it('should return isRequired error for dwp-check given empty strings', function () {
     try {
-      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', '', '', '', '', '', '', VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES)
+      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', '', '', '', '', '', '', VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES, NOT_ADVANCE_CLAIM)
       expect(false, 'should have thrown validation error').to.be.true
     } catch (e) {
       expect(e).to.be.instanceof(ValidationError)
@@ -75,7 +85,7 @@ describe('services/domain/claim-decision', function () {
 
   it('should return isRequired error for visit-confirmation-check given empty strings', function () {
     try {
-      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', '', '', '', '', '', '', '', VALID_CLAIMEXPENSES)
+      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', '', '', '', '', '', '', '', VALID_CLAIMEXPENSES, NOT_ADVANCE_CLAIM)
       expect(false, 'should have thrown validation error').to.be.true
     } catch (e) {
       expect(e).to.be.instanceof(ValidationError)
@@ -85,7 +95,7 @@ describe('services/domain/claim-decision', function () {
 
   it('should return error for invalid claim expenses', function () {
     try {
-      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', '', '', '', '', '', '', VALID_VISIT_CONFIRMATION_CHECK, INVALID_CLAIMEXPENSES)
+      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', '', '', '', '', '', '', VALID_VISIT_CONFIRMATION_CHECK, INVALID_CLAIMEXPENSES, NOT_ADVANCE_CLAIM)
       expect(false, 'should have thrown validation error').to.be.true
     } catch (e) {
       expect(e).to.be.instanceof(ValidationError)
@@ -95,7 +105,7 @@ describe('services/domain/claim-decision', function () {
 
   it('should return error if approving with all expenses rejected', function () {
     try {
-      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', VALID_DECISION_APPROVED, '', '', '', '', '', VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES_REJECTED)
+      claimDecision = new ClaimDecision(VALID_CASEWORKER, '', VALID_DECISION_APPROVED, '', '', '', '', '', VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES_REJECTED, NOT_ADVANCE_CLAIM)
       expect(false, 'should have thrown validation error').to.be.true
     } catch (e) {
       expect(e).to.be.instanceof(ValidationError)
@@ -105,7 +115,7 @@ describe('services/domain/claim-decision', function () {
 
   it('should return error if same caseworker as assisted digital caseworker', function () {
     try {
-      claimDecision = new ClaimDecision(VALID_CASEWORKER, VALID_CASEWORKER, '', '', '', '', '', '', VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES_REJECTED)
+      claimDecision = new ClaimDecision(VALID_CASEWORKER, VALID_CASEWORKER, '', '', '', '', '', '', VALID_VISIT_CONFIRMATION_CHECK, VALID_CLAIMEXPENSES_REJECTED, NOT_ADVANCE_CLAIM)
       expect(false, 'should have thrown validation error').to.be.true
     } catch (e) {
       expect(e).to.be.instanceof(ValidationError)

--- a/test/unit/views/helpers/test-display-helper.js
+++ b/test/unit/views/helpers/test-display-helper.js
@@ -7,6 +7,7 @@ const claimStatusEnum = require('../../../../app/constants/claim-status-enum')
 const claimTypeEnum = require('../../../../app/constants/claim-type-enum')
 const deductionTypeEnum = require('../../../../app/constants/deduction-type-enum')
 const rulesEnum = require('../../../../app/constants/region-rules-enum')
+const moment = require('moment')
 
 describe('views/helpers/display-helper', function () {
   const VALID_BENEFIT_VALUE = benefitsEnum.INCOME_SUPPORT.value
@@ -17,6 +18,11 @@ describe('views/helpers/display-helper', function () {
 
   const CLOSED_CLAIM_STATUS_VALUE = claimStatusEnum.APPROVED.value
   const NOT_CLOSED_CLAIM_STATUS_VALUE = claimStatusEnum.NEW.value
+
+  const ADVANCE_UPDATED_CLAIM_STATUS_VALUE = claimStatusEnum.UPDATED.value
+  const IS_ADVANCE_CLAIM = true
+  const DATE_OF_JOURNEY_PAST = moment().toDate()
+  const FUTURE_DATE_OF_JOURNEY = moment().add('2', 'days').toDate()
 
   it('should return the correct benefit display name given a valid value', function () {
     var result = displayHelper.getBenefitDisplayName(VALID_BENEFIT_VALUE)
@@ -61,6 +67,11 @@ describe('views/helpers/display-helper', function () {
   it('should return the correct closed value given a valid claim status', function () {
     expect(displayHelper.getClaimStatusClosed(CLOSED_CLAIM_STATUS_VALUE)).to.be.true
     expect(displayHelper.getClaimStatusClosed(NOT_CLOSED_CLAIM_STATUS_VALUE)).to.be.false
+  })
+
+  it('should return the correct closed value given a valid advance updated claim status and date of journey', function () {
+    expect(displayHelper.getClaimStatusClosed(ADVANCE_UPDATED_CLAIM_STATUS_VALUE, IS_ADVANCE_CLAIM, DATE_OF_JOURNEY_PAST)).to.be.true
+    expect(displayHelper.getClaimStatusClosed(ADVANCE_UPDATED_CLAIM_STATUS_VALUE, IS_ADVANCE_CLAIM, FUTURE_DATE_OF_JOURNEY)).to.be.false
   })
 
   it('should return the correct value given a valid integer or decimal number', function () {


### PR DESCRIPTION
Removed option to approve and reject visit confirmation on advance claims
 
* Updated view to not display select box for visit confirmation on advance claims
* Updated view for when it displayed the closed claim options
* Updated display helper for closed claims
* Updated domain to not validate Visit confirmation on making decision on advance claims

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards