### PR TITLE
Removing DWP benefit checker result from result

### DIFF
--- a/seeds/add-get-historic-claims-function.js
+++ b/seeds/add-get-historic-claims-function.js
@@ -33,8 +33,7 @@ exports.seed = function (knex, Promise) {
                 Claim.VisitConfirmationCheck,
                 Claim.IsAdvanceClaim,
                 Prisoner.NomisCheck,
-                Claim.DateSubmitted,
-                Visitor.DWPBenefitCheckerResult
+                Claim.DateSubmitted
               FROM IntSchema.Claim AS Claim
                 JOIN IntSchema.Visitor AS Visitor ON Visitor.EligibilityId = Claim.EligibilityId
                 JOIN IntSchema.Prisoner AS Prisoner ON Prisoner.EligibilityId = Claim.EligibilityId


### PR DESCRIPTION
Removing DWP benefit checker result from getHistoricClaims db function that was added in a previous commit