### PR TITLE
Displaying any documents that have been uploaded, not just if they ar…

### DIFF
--- a/app/views/partials/view-claim/visitor.html
+++ b/app/views/partials/view-claim/visitor.html
@@ -53,7 +53,7 @@
       {% endif %}
       <br/>
 
-      {% if displayHelper.getBenefitRequireUpload(Claim['Benefit']) %}
+      {% if displayHelper.getBenefitRequireUpload(Claim['Benefit']) or Claim.benefitDocument.length > 0 %}
       {% for document in Claim.benefitDocument %}
         <br>
         {% if document['DocumentStatus'] == 'uploaded' %}


### PR DESCRIPTION
Displaying any uploaded documents, not just when documents are expected to be uploaded - allows failed DWP check benefit information to be viewed.